### PR TITLE
BES 87

### DIFF
--- a/ConstraintEvaluator.cc
+++ b/ConstraintEvaluator.cc
@@ -271,7 +271,7 @@ ConstraintEvaluator::eval_function_clauses(DDS &dds)
         }
         else {
             delete fdds;
-            throw Error("A function was called but failed to return a value.");
+            throw Error(internal_error, "A function was called but failed to return a value.");
         }
     }
 
@@ -300,7 +300,7 @@ ConstraintEvaluator::eval_function_clauses(DataDDS &dds)
         }
         else {
             delete fdds;
-            throw Error("A function was called but failed to return a value.");
+            throw Error(internal_error, "A function was called but failed to return a value.");
         }
     }
 

--- a/Error.cc
+++ b/Error.cc
@@ -65,7 +65,8 @@ static const char *err_messages[] = {
     "Malformed expression",
     "No authorization",
     "Cannot read file",
-    "Cannot read file"
+    "Not Implemented",
+    ""
 };
 
 /** Specializations of Error should use this to set the error code and

--- a/Error.h
+++ b/Error.h
@@ -65,7 +65,7 @@ typedef int ErrorCode; //using standard errno+netCDF error codes from server
 #define    no_authorization  1006 ///< (401)
 #define    cannot_read_file  1007 ///< (400)
 #define    not_implemented   1008 ///< Implies that it will/might be impl. (501)
-#define    dummy_code        1009 ///< @see Error.cc; end the array with ""
+#define    dummy_message     1009 ///< @see Error.cc; end the array with ""
 //@}
 
 /** The Error class is used to transport error information from the server to

--- a/Error.h
+++ b/Error.h
@@ -57,15 +57,15 @@ typedef int ErrorCode; //using standard errno+netCDF error codes from server
 /** @name Internal DAP errors */
 //@{
 #define    undefined_error   1000 ///< Undefined error code
-#define    unknown_error     1001 ///< Unknown error
-#define    internal_error    1002 ///< Internal server error
+#define    unknown_error     1001 ///< Unknown error (the default code) (HTTP 400)
+#define    internal_error    1002 ///< Internal server error (500)
 #define    no_such_file      1003
 #define    no_such_variable  1004
 #define    malformed_expr    1005
 #define    no_authorization  1006
 #define    cannot_read_file  1007
-#define    dummy_message     1008 // Duplicate of 1007; see Error.cc
-
+#define    not_implemented   1008 ///< Implies that it will/might be impl. (501)
+#define    dummy_code        1009 ///< @see Error.cc; end the array with ""
 //@}
 
 /** The Error class is used to transport error information from the server to

--- a/Error.h
+++ b/Error.h
@@ -56,14 +56,14 @@ typedef int ErrorCode; //using standard errno+netCDF error codes from server
 
 /** @name Internal DAP errors */
 //@{
-#define    undefined_error   1000 ///< Undefined error code
+#define    undefined_error   1000 ///< Undefined error code, an empty Error object was built
 #define    unknown_error     1001 ///< Unknown error (the default code) (HTTP 400)
 #define    internal_error    1002 ///< Internal server error (500)
-#define    no_such_file      1003
-#define    no_such_variable  1004
-#define    malformed_expr    1005
-#define    no_authorization  1006
-#define    cannot_read_file  1007
+#define    no_such_file      1003 ///< (400)
+#define    no_such_variable  1004 ///< (400)
+#define    malformed_expr    1005 ///< (400)
+#define    no_authorization  1006 ///< (401)
+#define    cannot_read_file  1007 ///< (400)
 #define    not_implemented   1008 ///< Implies that it will/might be impl. (501)
 #define    dummy_code        1009 ///< @see Error.cc; end the array with ""
 //@}

--- a/Error.h
+++ b/Error.h
@@ -64,7 +64,7 @@ typedef int ErrorCode; //using standard errno+netCDF error codes from server
 #define    malformed_expr    1005
 #define    no_authorization  1006
 #define    cannot_read_file  1007
-#define    dummy_message     1008 // Dumplicate of 1007; see Error.cc
+#define    dummy_message     1008 // Duplicate of 1007; see Error.cc
 
 //@}
 

--- a/HTTPCache.cc
+++ b/HTTPCache.cc
@@ -266,7 +266,7 @@ HTTPCache::HTTPCache(string cache_root, bool force) :
 	int block_size;
 
 	if (!get_single_user_lock(force))
-	    throw Error("Could not get single user lock for the cache");
+	    throw Error(internal_error, "Could not get single user lock for the cache");
 
 #ifdef WIN32
 	//  Windows is unable to provide us this information.  4096 appears
@@ -279,7 +279,7 @@ HTTPCache::HTTPCache(string cache_root, bool force) :
 	if (stat(cache_root.c_str(), &s) == 0)
 		block_size = s.st_blksize;
 	else
-		throw Error("Could not set file system block size.");
+		throw Error(internal_error, "Could not set file system block size.");
 #endif
 	d_http_cache_table = new HTTPCacheTable(d_cache_root, block_size);
 	d_cache_enabled = true;
@@ -1258,7 +1258,7 @@ HTTPCache::get_conditional_request_headers(const string &url)
     try {
         entry = d_http_cache_table->get_locked_entry_from_cache_table(url);
         if (!entry)
-            throw Error("There is no cache entry for the URL: " + url);
+            throw Error(internal_error, "There is no cache entry for the URL: " + url);
 
         if (entry->get_etag() != "")
             headers.push_back(string("If-None-Match: ") + entry->get_etag());
@@ -1327,7 +1327,7 @@ HTTPCache::update_response(const string &url, time_t request_time,
     try {
         entry = d_http_cache_table->get_write_locked_entry_from_cache_table(url);
         if (!entry)
-            throw Error("There is no cache entry for the URL: " + url);
+            throw Error(internal_error, "There is no cache entry for the URL: " + url);
 
         // Merge the new headers with the exiting HTTPCacheTable::CacheEntry object.
         d_http_cache_table->parse_headers(entry, d_max_entry_size, headers);
@@ -1402,7 +1402,7 @@ HTTPCache::is_url_valid(const string &url)
 
         entry = d_http_cache_table->get_locked_entry_from_cache_table(url);
         if (!entry)
-            throw Error("There is no cache entry for the URL: " + url);
+            throw Error(internal_error, "There is no cache entry for the URL: " + url);
 
         // If we supported range requests, we'd need code here to check if
         // there was only a partial response in the cache. 10/02/02 jhrg
@@ -1603,7 +1603,7 @@ HTTPCache::purge_cache()
 
     try {
         if (d_http_cache_table->is_locked_read_responses())
-            throw Error("Attempt to purge the cache with entries in use.");
+            throw Error(internal_error, "Attempt to purge the cache with entries in use.");
 
         d_http_cache_table->delete_all_entries();
     }

--- a/HTTPCacheTable.cc
+++ b/HTTPCacheTable.cc
@@ -385,7 +385,7 @@ public:
                          (long)(e->response_time),
                          (long)(e->corrected_initial_age),
                          e->must_revalidate ? '1' : '0') < 0)
-            throw Error("Cache Index. Error writing cache index\n");
+            throw Error(internal_error, "Cache Index. Error writing cache index\n");
     }
 };
 
@@ -478,7 +478,7 @@ HTTPCacheTable::create_hash_directory(int hash)
     errno = 0;
     if (mkdir(path.str().c_str(), 0777) < 0 && errno != EEXIST) {
         umask(mask);
-        throw Error("Could not create the directory for the cache at '" + path.str() + "' (" + strerror(errno) + ").");
+        throw Error(internal_error, "Could not create the directory for the cache at '" + path.str() + "' (" + strerror(errno) + ").");
     }
 
     // Restore themask
@@ -528,7 +528,7 @@ HTTPCacheTable::create_location(HTTPCacheTable::CacheEntry *entry)
     if (fd < 0) {
         // delete[] templat; templat = 0;
         // close(fd); Calling close() when fd is < 0 is a bad idea! jhrg 7/2/15
-        throw Error("The HTTP Cache could not create a file to hold the response; it will not be cached.");
+        throw Error(internal_error, "The HTTP Cache could not create a file to hold the response; it will not be cached.");
     }
 
     entry->cachename = &templat[0];

--- a/MarshallerThread.cc
+++ b/MarshallerThread.cc
@@ -152,12 +152,12 @@ ChildLocker::~ChildLocker()
 MarshallerThread::MarshallerThread() :
     d_thread(0), d_child_thread_count(0)
 {
-    if (pthread_attr_init(&d_thread_attr) != 0) throw Error("Failed to initialize pthread attributes.");
+    if (pthread_attr_init(&d_thread_attr) != 0) throw Error(internal_error, "Failed to initialize pthread attributes.");
     if (pthread_attr_setdetachstate(&d_thread_attr, PTHREAD_CREATE_DETACHED /*PTHREAD_CREATE_JOINABLE*/) != 0)
-        throw Error("Failed to complete pthread attribute initialization.");
+        throw Error(internal_error, "Failed to complete pthread attribute initialization.");
 
-    if (pthread_mutex_init(&d_out_mutex, 0) != 0) throw Error("Failed to initialize mutex.");
-    if (pthread_cond_init(&d_out_cond, 0) != 0) throw Error("Failed to initialize cond.");
+    if (pthread_mutex_init(&d_out_mutex, 0) != 0) throw Error(internal_error, "Failed to initialize mutex.");
+    if (pthread_cond_init(&d_out_cond, 0) != 0) throw Error(internal_error, "Failed to initialize cond.");
 }
 
 MarshallerThread::~MarshallerThread()

--- a/Operators.h
+++ b/Operators.h
@@ -67,9 +67,9 @@ bool Cmp(int op, T1 v1, T2 v2)
         case SCAN_LESS_EQL:
             return v1 <= v2;
         case SCAN_REGEXP:
-            throw Error("Regular expressions are supported for strings only.");
+            throw Error(malformed_expr, "Regular expressions are supported for strings only.");
         default:
-            throw Error("Unrecognized operator.");
+            throw Error(malformed_expr, "Unrecognized operator.");
     }
 }
 
@@ -104,9 +104,9 @@ bool USCmp(int op, UT1 v1, T2 v2)
         case SCAN_LESS_EQL:
             return v1 <= dap_floor_zero<T2>(v2);
         case SCAN_REGEXP:
-            throw Error("Regular expressions are supported for strings only.");
+            throw Error(malformed_expr, "Regular expressions are supported for strings only.");
         default:
-            throw Error("Unrecognized operator.");
+            throw Error(malformed_expr, "Unrecognized operator.");
     }
 }
 
@@ -139,9 +139,9 @@ bool SUCmp(int op, T1 v1, UT2 v2)
         case SCAN_LESS_EQL:
             return dap_floor_zero<T1>(v1) <= v2;
         case SCAN_REGEXP:
-            throw Error("Regular expressions are supported for strings only.");
+            throw Error(malformed_expr, "Regular expressions are supported for strings only.");
         default:
-            throw Error("Unrecognized operator.");
+            throw Error(malformed_expr, "Unrecognized operator.");
     }
 }
 
@@ -171,7 +171,7 @@ bool StrCmp(int op, T1 v1, T2 v2)
             return r.match(v1.c_str(), v1.length()) > 0;
         }
         default:
-            throw Error("Unrecognized operator.");
+            throw Error(malformed_expr, "Unrecognized operator.");
     }
 }
 

--- a/RCReader.cc
+++ b/RCReader.cc
@@ -221,8 +221,7 @@ bool RCReader::read_rc_file(const string &pathname)
                     d_dods_proxy_server_protocol = proxy.substr(0, comma);
                     downcase(d_dods_proxy_server_protocol);
                     if (d_dods_proxy_server_protocol != "http")
-                        throw Error(
-                                "The only supported protocol for a proxy server is \"HTTP\". Correct your \".dodsrc\" file.");
+                        throw Error("The only supported protocol for a proxy server is \"HTTP\". Correct your \".dodsrc\" file.");
                     proxy = proxy.substr(comma + 1);
                 }
                 else {

--- a/Sequence.cc
+++ b/Sequence.cc
@@ -1318,8 +1318,7 @@ void Sequence::set_leaf_sequence(int lvl)
         // in serialize_leaf() and serialize_parent_part_one()).
         if ((*iter)->type() == dods_sequence_c && (*iter)->send_p()) {
             if (has_child_sequence)
-                throw Error(
-                        "This implementation does not support more than one nested sequence at a level. Contact the server administrator.");
+                throw Error("This implementation does not support more than one nested sequence at a level. Contact the server administrator.");
 
             has_child_sequence = true;
             static_cast<Sequence&>(**iter).set_leaf_sequence(++lvl);

--- a/SignalHandler.cc
+++ b/SignalHandler.cc
@@ -119,7 +119,7 @@ SignalHandler::dispatcher(int signum)
         // Calling _exit() or abort() is not a good thing for a library to be
         // doing. This results in a warning from rpmlint
         default:
-            throw Error("Signal handler operation on an unsupported signal.");
+            throw Error(internal_error, "Signal handler operation on an unsupported signal.");
         }
     }
     else

--- a/XDRFileMarshaller.cc
+++ b/XDRFileMarshaller.cc
@@ -122,15 +122,13 @@ void XDRFileMarshaller::put_float64(dods_float64 val)
 void XDRFileMarshaller::put_uint16(dods_uint16 val)
 {
     if (!XDR_UINT16(_sink, &val))
-        throw Error(
-            "Network I/O Error. Could not send uint 16 data. This may be due to a\nbug in libdap or a problem with the network connection.");
+        throw Error("Network I/O Error. Could not send uint 16 data.");
 }
 
 void XDRFileMarshaller::put_uint32(dods_uint32 val)
 {
     if (!XDR_UINT32(_sink, &val))
-        throw Error(
-            "Network I/O Error. Could not send uint 32 data. This may be due to a\nbug in libdap or a problem with the network connection.");
+        throw Error("Network I/O Error. Could not send uint 32 data.");
 }
 
 void XDRFileMarshaller::put_str(const string &val)
@@ -138,8 +136,7 @@ void XDRFileMarshaller::put_str(const string &val)
     const char *out_tmp = val.c_str();
 
     if (!xdr_string(_sink, (char **) &out_tmp, max_str_len))
-        throw Error(
-            "Network I/O Error. Could not send string data.\nThis may be due to a bug in libdap, on the server or a\nproblem with the network connection.");
+        throw Error("Network I/O Error. Could not send string data.");
 }
 
 void XDRFileMarshaller::put_url(const string &val)
@@ -150,15 +147,13 @@ void XDRFileMarshaller::put_url(const string &val)
 void XDRFileMarshaller::put_opaque(char *val, unsigned int len)
 {
     if (!xdr_opaque(_sink, val, len))
-        throw Error(
-            "Network I/O Error. Could not send opaque data.\nThis may be due to a bug in libdap, on the server or a\nproblem with the network connection.");
+        throw Error("Network I/O Error. Could not send opaque data.");
 }
 
 void XDRFileMarshaller::put_int(int val)
 {
     if (!xdr_int(_sink, &val))
-        throw Error(
-            "Network I/O Error(1). This may be due to a bug in libdap or a\nproblem with the network connection.");
+        throw Error("Network I/O Error(1).");
 }
 
 void XDRFileMarshaller::put_vector(char *val, int num, Vector &)
@@ -168,8 +163,7 @@ void XDRFileMarshaller::put_vector(char *val, int num, Vector &)
     put_int(num);
 
     if (!xdr_bytes(_sink, (char **) &val, (unsigned int *) &num, DODS_MAX_ARRAY)) {
-        throw Error(
-            "Network I/O Error(2). This may be due to a bug in libdap or a\nproblem with the network connection.");
+        throw Error("Network I/O Error(2).");
     }
 }
 
@@ -182,8 +176,7 @@ void XDRFileMarshaller::put_vector(char *val, int num, int width, Vector &vec)
     BaseType *var = vec.var();
     if (!xdr_array(_sink, (char **) &val, (unsigned int *) &num, DODS_MAX_ARRAY, width,
         XDRUtils::xdr_coder(var->type()))) {
-        throw Error(
-            "Network I/O Error(2). This may be due to a bug in libdap or a\nproblem with the network connection.");
+        throw Error("Network I/O Error(2).");
     }
 }
 

--- a/XDRFileUnMarshaller.cc
+++ b/XDRFileUnMarshaller.cc
@@ -94,49 +94,49 @@ void
 XDRFileUnMarshaller::get_byte( dods_byte &val )
 {
     if( !xdr_char( _source, (char *)&val ) )
-        throw Error("Network I/O Error. Could not read byte data. This may be due to a\nbug in DODS or a problem with the network connection.");
+        throw Error("Network I/O Error. Could not read byte data.");
 }
 
 void
 XDRFileUnMarshaller::get_int16( dods_int16 &val )
 {
     if( !XDR_INT16( _source, &val ) )
-        throw Error("Network I/O Error. Could not read int 16 data. This may be due to a\nbug in libdap or a problem with the network connection.");
+        throw Error("Network I/O Error. Could not read int 16 data.");
 }
 
 void
 XDRFileUnMarshaller::get_int32( dods_int32 &val )
 {
     if( !XDR_INT32( _source, &val ) )
-        throw Error("Network I/O Error. Could not read int 32 data. This may be due to a\nbug in libdap or a problem with the network connection.");
+        throw Error("Network I/O Error. Could not read int 32 data.");
 }
 
 void
 XDRFileUnMarshaller::get_float32( dods_float32 &val )
 {
     if( !xdr_float( _source, &val ) )
-        throw Error("Network I/O Error. Could not read float 32 data. This may be due to a\nbug in libdap or a problem with the network connection.");
+        throw Error("Network I/O Error. Could not read float 32 data.");
 }
 
 void
 XDRFileUnMarshaller::get_float64( dods_float64 &val )
 {
     if( !xdr_double( _source, &val ) )
-        throw Error("Network I/O Error. Could not read float 64 data. This may be due to a\nbug in libdap or a problem with the network connection.");
+        throw Error("Network I/O Error.Could not read float 64 data.");
 }
 
 void
 XDRFileUnMarshaller::get_uint16( dods_uint16 &val )
 {
     if( !XDR_UINT16( _source, &val ) )
-        throw Error("Network I/O Error. Could not read uint 16 data. This may be due to a\nbug in libdap or a problem with the network connection.");
+        throw Error("Network I/O Error. Could not read uint 16 data.");
 }
 
 void
 XDRFileUnMarshaller::get_uint32( dods_uint32 &val )
 {
     if( !XDR_UINT32( _source, &val ) )
-        throw Error("Network I/O Error. Could not read uint 32 data. This may be due to a\nbug in libdap or a problem with the network connection.");
+        throw Error("Network I/O Error. Could not read uint 32 data.");
 }
 
 void
@@ -145,7 +145,7 @@ XDRFileUnMarshaller::get_str( string &val )
     char *in_tmp = NULL ;
 
     if( !xdr_string( _source, &in_tmp, max_str_len ) )
-        throw Error("Network I/O Error. Could not read string data.\nThis may be due to a bug in libdap, on the server or a\nproblem with the network connection.");
+        throw Error("Network I/O Error. Could not read string data.");
 
     val = in_tmp ;
 
@@ -175,7 +175,7 @@ void
 XDRFileUnMarshaller::get_vector( char **val, unsigned int &num, Vector & )
 {
     if( !xdr_bytes( _source, val, &num, DODS_MAX_ARRAY) )
-	throw Error("Network I/O error. Could not read packed array data.\nThis may be due to a bug in libdap or a problem with\nthe network connection.");
+	throw Error("Network I/O error (1).");
 }
 
 void
@@ -186,7 +186,7 @@ XDRFileUnMarshaller::get_vector( char **val, unsigned int &num, int width, Vecto
     if( !xdr_array( _source, val, &num, DODS_MAX_ARRAY, width,
 		    XDRUtils::xdr_coder( var->type() ) ) )
     {
-	throw Error("Network I/O error. Could not read packed array data.\nThis may be due to a bug in libdap or a problem with\nthe network connection.");
+	throw Error("Network I/O error (2).");
     }
 }
 

--- a/XDRStreamMarshaller.cc
+++ b/XDRStreamMarshaller.cc
@@ -78,7 +78,7 @@ XDRStreamMarshaller::XDRStreamMarshaller(ostream &out) :
     d_out(out), d_partial_put_byte_count(0), tm(0)
 {
     if (!d_buf) d_buf = (char *) malloc(XDR_DAP_BUFF_SIZE);
-    if (!d_buf) throw Error("Failed to allocate memory for data serialization.");
+    if (!d_buf) throw Error(internal_error, "Failed to allocate memory for data serialization.");
 
     xdrmem_create(&d_sink, d_buf, XDR_DAP_BUFF_SIZE, XDR_ENCODE);
 
@@ -97,8 +97,7 @@ XDRStreamMarshaller::~XDRStreamMarshaller()
 void XDRStreamMarshaller::put_byte(dods_byte val)
 {
      if (!xdr_setpos(&d_sink, 0))
-        throw Error(
-            "Network I/O Error. Could not send byte data - unable to set stream position.");
+        throw Error("Network I/O Error. Could not send byte data - unable to set stream position.");
 
     if (!xdr_char(&d_sink, (char *) &val))
         throw Error(
@@ -212,7 +211,7 @@ void XDRStreamMarshaller::put_uint16(dods_uint16 val)
 
     if (!XDR_UINT16(&d_sink, &val))
         throw Error(
-            "Network I/O Error. Could not send uint 16 data. This may be due to a\nbug in libdap or a problem with the network connection.");
+            "Network I/O Error. Could not send uint 16 data.");
 
     unsigned int bytes_written = xdr_getpos(&d_sink);
     if (!bytes_written)
@@ -234,7 +233,7 @@ void XDRStreamMarshaller::put_uint32(dods_uint32 val)
 
     if (!XDR_UINT32(&d_sink, &val))
         throw Error(
-            "Network I/O Error. Could not send uint 32 data. This may be due to a\nbug in libdap or a problem with the network connection.");
+            "Network I/O Error. Could not send uint 32 data.");
 
     unsigned int bytes_written = xdr_getpos(&d_sink);
     if (!bytes_written)

--- a/XDRStreamUnMarshaller.cc
+++ b/XDRStreamUnMarshaller.cc
@@ -56,7 +56,7 @@ XDRStreamUnMarshaller::XDRStreamUnMarshaller(istream &in) : /*&d_source( 0 ),*/
     if (!d_buf)
         d_buf = (char *) malloc(XDR_DAP_BUFF_SIZE);
     if (!d_buf)
-        throw Error("Failed to allocate memory for data serialization.");
+        throw Error(internal_error, "Failed to allocate memory for data serialization.");
 
     //&d_source = new XDR;
     xdrmem_create(&d_source, d_buf, XDR_DAP_BUFF_SIZE, XDR_DECODE);

--- a/ce_expr.lex
+++ b/ce_expr.lex
@@ -58,7 +58,7 @@
 
 #define YY_DECL int ce_exprlex YY_PROTO(( void ))
 #define YY_FATAL_ERROR(msg) {\
-    throw(Error(string("Error scanning constraint expression text: ") + string(msg))); \
+    throw(libdap::Error(malformed_expr, std::string("Error scanning constraint expression text: ") + std::string(msg))); \
     yy_fatal_error(msg); /* see das.lex */ \
 }
 

--- a/ce_expr.yy
+++ b/ce_expr.yy
@@ -355,7 +355,7 @@ array_const_special_form: SCAN_HASH_FLOAT64 '(' arg_length_hint ':' fast_float64
 arg_length_hint: SCAN_WORD
           {
               if (!check_int32($1))
-                  throw Error(malformed_expr, "#<type>(hint, value, ...) special form expected hint to be an integer");
+                  throw Error(malformed_expr, "$<type>(hint, value, ...) special form expected hint to be an integer");
                    
               arg_length_hint_value = atoi($1);
               $$ = true;
@@ -838,28 +838,30 @@ rel_op:		SCAN_EQUAL
 void
 ce_exprerror(ce_parser_arg *, const string &s)
 {
-    //ce_exprerror(s.c_str());
-    string msg = "Constraint expression parse error: " + (string) s;
+    string msg = "Constraint expression parse error: " +s;
     throw Error(malformed_expr, msg);
 }
 
 void ce_exprerror(ce_parser_arg *, const string &s, const string &s2)
 {
-    //ce_exprerror(s.c_str(), s2.c_str());
-    string msg = "Constraint expression parse error: " + (string) s + ": " + (string) s2;
+    string msg = "Constraint expression parse error: " + s + ": " + s2;
     throw Error(malformed_expr, msg);    
 }
 
 void no_such_ident(ce_parser_arg *arg, const string &name, const string &word)
 {
+#if 0
     string msg = "No such " + word + " in dataset";
-    ce_exprerror(arg, msg /*.c_str()*/, name);
+    ce_exprerror(arg, msg , name);
+#endif
+    string msg = "Constraint expression parse error: No such " + word + " in dataset: " + name;
+    throw Error(no_such_variable, msg);    
+    
 }
 
 void no_such_func(ce_parser_arg *arg, const string &name)
 {
     ce_exprerror(arg, "Not a registered function", name);
-    //no_such_func(name/*.c_str()*/);
 }
 
 /* If we're calling this, assume var is not a Sequence. But assume that the

--- a/d4_ce/D4ConstraintEvaluator.cc
+++ b/d4_ce/D4ConstraintEvaluator.cc
@@ -65,14 +65,14 @@ D4ConstraintEvaluator::set_array_slices(const std::string &id, Array *a)
 {
     // Test that the indexes and dimensions match in number
     if (d_indexes.size() != a->dimensions())
-        throw Error("The index constraint for '" + id + "' does not match its rank.");
+        throw Error(malformed_expr, "The index constraint for '" + id + "' does not match its rank.");
 
     Array::Dim_iter d = a->dim_begin();
     for (vector<index>::iterator i = d_indexes.begin(), e = d_indexes.end(); i != e; ++i) {
         if ((*i).stride > (unsigned long long)a->dimension_stop(d, false))
-            throw Error("For '" + id + "', the index stride value is greater than the number of elements in the Array");
+            throw Error(malformed_expr, "For '" + id + "', the index stride value is greater than the number of elements in the Array");
         if (!(*i).rest && ((*i).stop) > (unsigned long long)a->dimension_stop(d, false))
-            throw Error("For '" + id + "', the index stop value is greater than the number of elements in the Array");
+            throw Error(malformed_expr, "For '" + id + "', the index stop value is greater than the number of elements in the Array");
 
         D4Dimension *dim = a->dimension_D4dim(d);
 
@@ -98,13 +98,13 @@ D4ConstraintEvaluator::set_array_slices(const std::string &id, Array *a)
 void
 D4ConstraintEvaluator::throw_not_found(const string &id, const string &ident)
 {
-    throw Error(d_expr + ": The variable " + id + " was not found in the dataset (" + ident + ").");
+    throw Error(no_such_variable, d_expr + ": The variable " + id + " was not found in the dataset (" + ident + ").");
 }
 
 void
 D4ConstraintEvaluator::throw_not_array(const string &id, const string &ident)
 {
-	throw Error(d_expr + ": The variable '" + id + "' is not an Array variable (" + ident + ").");
+	throw Error(no_such_variable, d_expr + ": The variable '" + id + "' is not an Array variable (" + ident + ").");
 }
 
 void
@@ -205,14 +205,14 @@ D4ConstraintEvaluator::mark_array_variable(BaseType *btp)
     else {
         // Test that the indexes and dimensions match in number
         if (d_indexes.size() != a->dimensions())
-            throw Error("The index constraint for '" + btp->name() + "' does not match its rank.");
+            throw Error(malformed_expr, "The index constraint for '" + btp->name() + "' does not match its rank.");
 
         Array::Dim_iter d = a->dim_begin();
         for (vector<index>::iterator i = d_indexes.begin(), e = d_indexes.end(); i != e; ++i) {
             if ((*i).stride > (unsigned long long) (a->dimension_stop(d, false) - a->dimension_start(d, false)) + 1)
-                throw Error("For '" + btp->name() + "', the index stride value is greater than the number of elements in the Array");
+                throw Error(malformed_expr, "For '" + btp->name() + "', the index stride value is greater than the number of elements in the Array");
             if (!(*i).rest && ((*i).stop) > (unsigned long long) (a->dimension_stop(d, false) - a->dimension_start(d, false)) + 1)
-                throw Error("For '" + btp->name() + "', the index stop value is greater than the number of elements in the Array");
+                throw Error(malformed_expr, "For '" + btp->name() + "', the index stop value is greater than the number of elements in the Array");
 
             D4Dimension *dim = a->dimension_D4dim(d);
 
@@ -250,9 +250,9 @@ D4ConstraintEvaluator::slice_dimension(const std::string &id, const index &i)
     D4Dimension *dim = dmr()->root()->find_dim(id);
 
     if (i.stride > dim->size())
-        throw Error("For '" + id + "', the index stride value is greater than the size of the dimension");
+        throw Error(malformed_expr, "For '" + id + "', the index stride value is greater than the size of the dimension");
     if (!i.rest && (i.stop > dim->size() - 1))
-        throw Error("For '" + id + "', the index stop value is greater than the size of the dimension");
+        throw Error(malformed_expr, "For '" + id + "', the index stop value is greater than the size of the dimension");
 
     dim->set_constraint(i.start, i.stride, i.rest ? dim->size() - 1: i.stop);
 

--- a/d4_ce/d4_ce_parser.yy
+++ b/d4_ce/d4_ce_parser.yy
@@ -217,7 +217,7 @@ subset : id
     
     if (btp->type() == dods_array_c) {
         if (btp->var() && !btp->var()->is_constructor_type())
-            throw Error("The variable " + $1 + " must be a Structure or Sequence to be used with {}.");
+            throw Error(no_such_variable, "The variable " + $1 + " must be a Structure or Sequence to be used with {}.");
             
         // This call also tests the btp to make sure it's an array
         driver.mark_array_variable(btp);
@@ -226,7 +226,7 @@ subset : id
         // Don't mark the variable here because only some fields are to be sent and those
         // will be marked when the fields are parsed
         if (!btp->is_constructor_type())
-            throw Error("The variable " + $1 + " must be a Structure or Sequence to be used with {}.");
+            throw Error(no_such_variable, "The variable " + $1 + " must be a Structure or Sequence to be used with {}.");
     }
     
     // push the basetype (a ctor or array of ctor) on the stack so that it is
@@ -259,7 +259,7 @@ fields
     driver.mark_array_variable(btp);
     
     if (!btp->var()->is_constructor_type())
-        throw Error("The variable " + $1 + " must be a Structure or Sequence to be used with {}.");
+        throw Error(no_such_variable, "The variable " + $1 + " must be a Structure or Sequence to be used with {}.");
       
     driver.push_basetype(btp->var());       
 } 

--- a/d4_ce/d4_ce_scanner.ll
+++ b/d4_ce/d4_ce_scanner.ll
@@ -29,6 +29,7 @@
 //#include "config.h"
 
 #include <string>
+#include "Error.h"
 
 #include "D4CEScanner.h"
 
@@ -42,6 +43,10 @@ typedef libdap::D4CEParser::token token;
 
 /* define yyterminate as this instead of NULL */
 #define yyterminate() return(token::END)
+
+#define YY_FATAL_ERROR(msg) {\
+    throw(libdap::Error(malformed_expr, std::string("Error scanning constraint expression text: ") + std::string(msg))); \
+}
 
 %}
 

--- a/d4_function/D4FunctionEvaluator.cc
+++ b/d4_function/D4FunctionEvaluator.cc
@@ -115,7 +115,7 @@ void D4FunctionEvaluator::eval(DMR *function_result)
     if (ce_parser_debug) parser.set_trace_parsing(true);
     bool parse_ok = parser.parse(function);
     if (!parse_ok)
-    Error("Function Expression failed to parse.");
+    Error(malformed_expr, "Function Expression failed to parse.");
     else {
         if (ce_parser_debug) cerr << "Function Parse OK" << endl;
         D4RValueList *result = parser.result();

--- a/d4_function/d4_function_parser.yy
+++ b/d4_function/d4_function_parser.yy
@@ -180,7 +180,7 @@ fname: WORD
     D4Function f;
     if (!evaluator.sf_list()->find_function($1, &f)) {
         // ...cloud use @1.{first,last}_column in these error messages.
-        throw Error("'" + $1 + "' is not a registered DAP4 server function.");
+        throw Error(malformed_expr, "'" + $1 + "' is not a registered DAP4 server function.");
     }
 
     $$ = f;
@@ -216,7 +216,7 @@ variable_or_constant : id
 {
     D4RValue *rvalue = evaluator.build_rvalue($1);
     if (!rvalue) {
-        throw Error("'" + $1 + "' is not a variable, number or string.");
+        throw Error(malformed_expr, "'" + $1 + "' is not a variable, number or string.");
     }
     
     $$ = rvalue;

--- a/d4_function/d4_function_scanner.ll
+++ b/d4_function/d4_function_scanner.ll
@@ -30,6 +30,7 @@
 //#include "config.h"
 
 #include <string>
+#include "Error.h"
 
 #include "D4FunctionScanner.h"
 
@@ -58,6 +59,10 @@ typedef libdap::D4FunctionParser::token token;
 
 /* define yyterminate as this instead of NULL */
 #define yyterminate() return(token::END)
+
+#define YY_FATAL_ERROR(msg) {\
+    throw(libdap::Error(malformed_expr, std::string("Error scanning function expression text: ") + std::string(msg))); \
+}
 
 %}
 

--- a/das.lex
+++ b/das.lex
@@ -88,7 +88,7 @@ using namespace libdap ;
 #define YY_DECL int daslex YY_PROTO(( void ))
 #define YY_FATAL_ERROR(msg) {\
     throw(Error(string("Error scanning DAS object text: ") + string(msg))); \
-    yy_fatal_error(msg); /* This will never be run but putting it here removes a warning that the funtion is never used. */ \
+    yy_fatal_error(msg); /* This will never be run but putting it here removes a warning that the function is never used. */ \
 }
 
 #include "das.tab.hh"

--- a/mime_util.cc
+++ b/mime_util.cc
@@ -950,8 +950,7 @@ string read_multipart_boundary(FILE *in, const string &boundary)
     // The value of 'boundary_line' is returned by this function.
     if ((!boundary.empty() && is_boundary(boundary_line.c_str(), boundary))
 	    || boundary_line.find("--") != 0)
-	throw Error(
-		"The DAP4 data response document is broken - missing or malformed boundary.");
+	throw Error(internal_error, "The DAP4 data response document is broken - missing or malformed boundary.");
 
     return boundary_line;
 }
@@ -964,8 +963,7 @@ string read_multipart_boundary(istream &in, const string &boundary)
     // The value of 'boundary_line' is returned by this function.
     if ((!boundary.empty() && is_boundary(boundary_line.c_str(), boundary))
 	    || boundary_line.find("--") != 0)
-	throw Error(
-		"The DAP4 data response document is broken - missing or malformed boundary.");
+	throw Error(internal_error, "The DAP4 data response document is broken - missing or malformed boundary.");
 
     return boundary_line;
 }
@@ -1002,13 +1000,12 @@ void read_multipart_headers(FILE *in, const string &content_type, const ObjectTy
 		if (name == "content-type") {
 			ct = true;
 			if (value.find(content_type) == string::npos)
-				throw Error("Content-Type for this part of a DAP2 data ddx response must be " + content_type + ".");
+				throw Error(internal_error, "Content-Type for this part of a DAP2 data ddx response must be " + content_type + ".");
 		}
 		else if (name == "content-description") {
 			cd = true;
 			if (get_description_type(value) != object_type)
-				throw Error(
-						"Content-Description for this part of a DAP2 data ddx response must be dods-ddx or dods-data-ddx");
+				throw Error(internal_error, "Content-Description for this part of a DAP2 data ddx response must be dods-ddx or dods-data-ddx");
 		}
 		else if (name == "content-id") {
 			ci = true;
@@ -1019,7 +1016,7 @@ void read_multipart_headers(FILE *in, const string &content_type, const ObjectTy
 		header = get_next_mime_header(in);
 	}
 
-	if (!(ct && cd && ci)) throw Error("The DAP4 data response document is broken - missing header.");
+	if (!(ct && cd && ci)) throw Error(internal_error, "The DAP4 data response document is broken - missing header.");
 }
 
 void read_multipart_headers(istream &in, const string &content_type, const ObjectType object_type, const string &cid)
@@ -1034,7 +1031,7 @@ void read_multipart_headers(istream &in, const string &content_type, const Objec
 		if (name == "content-type") {
 			ct = true;
 			if (value.find(content_type) == string::npos)
-				throw Error("Content-Type for this part of a DAP4 data response must be " + content_type + ".");
+				throw Error(internal_error, "Content-Type for this part of a DAP4 data response must be " + content_type + ".");
 		}
 		else if (name == "content-description") {
 			cd = true;
@@ -1050,7 +1047,7 @@ void read_multipart_headers(istream &in, const string &content_type, const Objec
 		header = get_next_mime_header(in);
 	}
 
-	if (!(ct && cd && ci)) throw Error("The DAP4 data response document is broken - missing header.");
+	if (!(ct && cd && ci)) throw Error(internal_error, "The DAP4 data response document is broken - missing header.");
 }
 
 /** Given a Content-Id read from the DDX, return the value to look for in a
@@ -1065,7 +1062,7 @@ string cid_to_header_value(const string &cid)
 {
     string::size_type offset = cid.find("cid:");
     if (offset != 0)
-        throw Error("expected CID to start with 'cid:'");
+        throw Error(internal_error, "expected CID to start with 'cid:'");
 
     string value = "<";
     value.append(cid.substr(offset + 4));

--- a/parser-util.cc
+++ b/parser-util.cc
@@ -142,7 +142,7 @@ parse_error(const char *msg, const int line_num, const char *context)
     else
         oss += (string) "\n" + msg + (string) "\n";
 
-    throw Error(oss);
+    throw Error(malformed_expr, oss);
 }
 
 // context comes from the parser and will always be a char * unless the

--- a/util.cc
+++ b/util.cc
@@ -1220,14 +1220,14 @@ string open_temp_fstream(ofstream &f, const string &name_template, const string 
     // Use mkstemp to make and open the temp file atomically
     int tmpfile = mkstemps(&name[0], suffix.length());
     if (tmpfile == -1)
-        throw Error("Could not make a temporary file.");
+        throw Error(internal_error, "Could not make a temporary file.");
     // Open the file using C++ ofstream; get a C++ fstream object
     f.open(&name[0]);
     // Close the file descriptor; the file stays open because of the fstream object
     close(tmpfile);
     // Now test that the fstream object is valid
     if (f.fail())
-        throw Error("Could not make a temporary file.");
+        throw Error(internal_error, "Could not make a temporary file.");
 
     return string(&name[0]);
 }


### PR DESCRIPTION
I'd like to merge this ASAP since it's part of a larger set of changes in the BES and OLFS that result in much improved error reporting for Hyrax. I've looked at a number of calls that throw Error() w/o an error code and decided if that should remain the case (thus meaning the throw will result in a HTTP 400 return) or if they should be something else. Also note that the parsers and scanners now use Error() throws to signal various things and do not write to stderr.

Thanks,
James