### PR TITLE
ChangeLog, et al., updated Version 3.17.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,104 @@
+2016-01-20  James Gallagher  <jgallagher@opendap.org>
+
+	Removed #if 0 in the D4Function/ConstraintEvaluator::error() methods
+
+2016-01-19  James Gallagher  <jgallagher@opendap.org>
+
+	Found one more place in the DAP4 CE and Function parser where
+	errors did not result in an exception.
+
+2016-01-13  James Gallagher  <jgallagher@opendap.org>
+
+	Merge pull request #6 from OPENDAP/BES-87
+	BES 87
+
+2016-01-12  James Gallagher  <jgallagher@opendap.org>
+
+	Added comments re how the Error object codes map to HTTP codes
+
+	Added mapping between libdap and HTTP codes (suggestions)
+
+	Added a code to Error; made sure Error was used consistently
+	Changes to mesh with those in the OLFS. Error(unknown_error, ...)
+	maps to an HTTP 400, internal_error --> 500, not_impelemented -->501,
+	etc.
+
+	DAP2 and 4 scanners now throw Error(malformed_expr, <msg>)
+	They were writing to stderr...
+
+	DAP2 CE parser uses no_such_identifier where apropos
+
+2016-01-11  James Gallagher  <jgallagher@opendap.org>
+
+	Added codes Error response in the DAP2 parser
+
+	There were only a handful since most of the Error throws were well
+	behaved.
+
+	Modified the DAP4 ce and function parsers to include code w/Errors
+	See https://opendap.atlassian.net/browse/BES-87.
+
+2016-01-05  James Gallagher  <jgallagher@opendap.org>
+
+	Merge branch 'master' into bes-40
+
+2016-01-04  James Gallagher  <jgallagher@opendap.org>
+
+	Modified the CRC32 byte-order change so that it's not included by default
+
+	Popped old changes for Connect; fix for Makefile.am; etc.
+
+2015-12-31  James Gallagher  <jgallagher@opendap.org>
+
+	Hacks for doxygen.
+	The Makefile works now (rebuilds doxy.conf when needed) and the docs
+	are better. I stopped including docs for methods w/o doc comments
+	and those are now listed in the doxygen_warnings.txt file.
+	[ci skip]
+
+2015-12-30  James Gallagher  <jgallagher@opendap.org>
+
+	Tried CLion; added CMakeLists.txt to gitignore
+
+	Removed the calls to DDS:timeout_{on,off}
+	This code is no longer used. The timeout feature of the BES is far
+	better.
+
+2015-12-08  James Gallagher  <jgallagher@opendap.org>
+
+	Removed commented-out code
+
+	Merge branch 'master' of https://github.com/opendap/libdap4
+
+	Float32 attributes mis-coded as Byte in the DMR
+
+2015-12-03  Nathan Potter  <ndp@opendap.org>
+
+	Travis install check
+
+	Travis install check
+
+2015-11-30  Patrick West  <pwest@vsto.tw.rpi.edu>
+
+	Missing xml2 libraries in unit-tests build
+	Added $(XML2_LIBS) to the Makefile.am in unit-tests so that tests would
+	build. On Ubuntu 14.04.
+
+2015-11-12  James Gallagher  <jgallagher@opendap.org>
+
+	I removed the deploy lines from the travis.yml file
+	These seem broken - I have to investigate how to handle
+	deployment of RPMs out of travis
+
+2015-10-22  James Gallagher  <jgallagher@opendap.org>
+
+	Fixed error in printing of child groups.
+	The child group values were printed twice.
+
+2015-10-21  James Gallagher  <jgallagher@opendap.org>
+
+	Source release version, ChangeLog, News, ... for 3.16.0
+
 2015-10-19  James Gallagher  <jgallagher@opendap.org>
 
 	Fixes #1

--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,5 @@
 
-Updated for version 3.16.0 of the OPeNDAP DAP2/4 library software.
+Updated for version 3.17.0 of the OPeNDAP DAP2/4 library software.
 
 Installing the DAP2/4 library
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,21 @@
+News for version 3.17.0
+
+Better error reporting. Error objects are now always thrown with a
+code that 'make sense' and use the default code only when really
+necessary. This means that the BES will not report most Error throws
+as an internal error (only a few are) unless that's really the case.
+This is used, in turn, by the front end to make better error responses
+for users.
+
+The old timeout code is still present but not used. This matches 
+changes made in the BES to correctly process timeouts.
+
+Improved support for doxygen.
+
+Support for DAP4: Attributes were sometimes mis-coded as Byte when
+they should have been Float32. Fixed.
+
+Child Groups were sometimes printed twice. No more.
 
 News for version 3.16.0
 

--- a/README
+++ b/README
@@ -1,3 +1,8 @@
+Updated for version 3.17.0
+
+Bug fixes and improved error messages; see NEWS and ChangeLog for 
+details.
+
 Updated for 3.16.0
 
 libdap now supports parallel I/O for certain data write operations,

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.63)
 dnl Update version here and below at LIB_CURRENT, ..., if needed.
-AC_INIT(libdap, 3.16.0, opendap-tech@opendap.org)
+AC_INIT(libdap, 3.17.0, opendap-tech@opendap.org)
 AC_DEFINE(DAP_PROTOCOL_VERSION, ["4.0"], [Highest DAP version implemented?])
 AC_SUBST(DAP_PROTOCOL_VERSION)
 
@@ -31,13 +31,6 @@ AC_SUBST(PACKAGE_MAJOR_VERSION)
 AC_SUBST(PACKAGE_MINOR_VERSION)
 AC_SUBST(PACKAGE_SUBMINOR_VERSION)
 
-dnl Removed this; only the Array and Sequence classes ever have
-dnl constraints that need to be evaluated at run time (DAP4) or only
-dnl Sequences (DAP2). jhrg 9/4/13
-
-dnl AC_DEFINE(EVAL, 1, [Should all the classes run ConstraintEvaluator::eval()?])
-dnl AC_SUBST(EVAL)
-
 dnl flags for the compilers and linkers - set these before locating the
 dnl actual tools since some of the AC_PROG macros set these `flag variables'
 dnl to default values otherwise.
@@ -52,8 +45,8 @@ dnl increment AGE, set REVISION to 0.
 dnl Interfaces removed or changed (BAD, breaks upward compatibility):
 dnl ==> Increment CURRENT, set AGE and REVISION to 0.
 
-DAPLIB_CURRENT=21
-DAPLIB_AGE=0
+DAPLIB_CURRENT=22
+DAPLIB_AGE=1
 DAPLIB_REVISION=0
 AC_SUBST(DAPLIB_CURRENT)
 AC_SUBST(DAPLIB_AGE)
@@ -64,7 +57,7 @@ AC_SUBST(LIBDAP_VERSION)
 
 CLIENTLIB_CURRENT=7
 CLIENTLIB_AGE=1
-CLIENTLIB_REVISION=2
+CLIENTLIB_REVISION=3
 AC_SUBST(CLIENTLIB_CURRENT)
 AC_SUBST(CLIENTLIB_AGE)
 AC_SUBST(CLIENTLIB_REVISION)
@@ -74,7 +67,7 @@ AC_SUBST(CLIENTLIB_VERSION)
 
 SERVERLIB_CURRENT=13
 SERVERLIB_AGE=6
-SERVERLIB_REVISION=2
+SERVERLIB_REVISION=3
 AC_SUBST(SERVERLIB_CURRENT)
 AC_SUBST(SERVERLIB_AGE)
 AC_SUBST(SERVERLIB_REVISION)

--- a/libdap.spec
+++ b/libdap.spec
@@ -1,6 +1,6 @@
 Name: libdap
 Summary: The C++ DAP2/DAP4 library from OPeNDAP
-Version: 3.16.0
+Version: 3.17.0
 Release: 1%{?dist}
 
 License: LGPLv2+

--- a/main_page.doxygen
+++ b/main_page.doxygen
@@ -8,7 +8,7 @@
 
 \section intro Introduction
 
-This reference documentation corresponds to version 3.16.0 of libdap, a C++
+This reference documentation corresponds to version 3.17.0 of libdap, a C++
 implementation of DAP2, with some extensions. The libdap library
 includes classes and functions which implement DAP 2.0 as well as utilities
 which simpify building clients and servers for DAP 2.0 and DAP4.0. 


### PR DESCRIPTION
This is the first candidate for libdap 3.17.0.

NEWS:

Better error reporting. Error objects are now always thrown with a
code that 'make sense' and use the default code only when really
necessary. This means that the BES will not report most Error throws
as an internal error (only a few are) unless that's really the case.
This is used, in turn, by the front end to make better error responses
for users.

The old timeout code is still present but not used. This matches 
changes made in the BES to correctly process timeouts.

Improved support for doxygen.

Support for DAP4: Attributes were sometimes mis-coded as Byte when
they should have been Float32. Fixed.

Child Groups were sometimes printed twice. No more.

I would like to release the code on Monday 1 Feb. Please let me know if you have issues with this code by Friday 29 Jan.

Thanks,
James