### PR TITLE
fix big endian detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,11 +146,12 @@ AC_CHECK_MEMBERS([struct stat.st_blksize])
 AC_HEADER_TIME
 AC_STRUCT_TM
 AC_C_VOLATILE
-AC_C_BIGENDIAN([ac_word_order=big-endian], [ac_word_order=little-endian])
+AC_C_BIGENDIAN
 
 # This is used byt eh DMR tests which must choose the correct set of baselines
 # based on word order given that DAP4 uses 'reader make right' and thus the 
 # DAP4 data responses are different for different word order machines. jhrg 9/29/15
+AS_IF([test $ac_cv_c_bigendian = yes], [ac_word_order=big-endian], [ac_word_order=little-endian])
 AC_SUBST([ac_word_order])
         
 DODS_CHECK_SIZES

--- a/unit-tests/D4MarshallerTest.cc
+++ b/unit-tests/D4MarshallerTest.cc
@@ -56,7 +56,7 @@ static bool write_baselines = false;
 #undef DBG
 #define DBG(x) do { if (debug) (x); } while(false);
 
-#ifdef __BIG_ENDIAN__
+#if WORDS_BIGENDIAN
 const static string path = (string)TEST_SRC_DIR + "/D4-marshaller/big-endian";
 #else
 const static string path = (string)TEST_SRC_DIR + "/D4-marshaller/little-endian";

--- a/unit-tests/D4UnMarshallerTest.cc
+++ b/unit-tests/D4UnMarshallerTest.cc
@@ -56,7 +56,7 @@ static bool debug = false;
 #undef DBG
 #define DBG(x) do { if (debug) (x); } while(false);
 
-#ifdef __BIG_ENDIAN__
+#if WORDS_BIGENDIAN
 const static string path = string(TEST_SRC_DIR) + "/D4-marshaller/big-endian";
 #else
 const static string path = string(TEST_SRC_DIR) + "/D4-marshaller/little-endian";

--- a/util.cc
+++ b/util.cc
@@ -100,7 +100,7 @@ bool is_host_big_endian()
 
 #else
 
-#ifdef __BIG_ENDIAN__
+#if WORDS_BIGENDIAN
     return true;
 #else
     return false;


### PR DESCRIPTION
Currently there is a endian detection during configure, but the code relies
on non-portable __BIG_ENDIAN__ define. The default actions in AC_C_BIGENDIAN()
break setting the correct value for WORD_BIGENDIAN.

See also https://bugzilla.redhat.com/show_bug.cgi?id=962091#c48 for details about __BIG_ENDIAN__

Successfully tested with 3.16.0 on all Fedora architectures (s390, s390x, ppc64, ppc64le, i686, x86_64, armv7, aarch64). 3.17.0 has new problems on big endian arches.