### PR TITLE
D4StreamMarshaller now uses the double buffering code for transmission

### DIFF
--- a/D4StreamMarshaller.cc
+++ b/D4StreamMarshaller.cc
@@ -28,6 +28,7 @@
 
 #include <byteswap.h>
 #include <cassert>
+#include <cstring>
 
 #include <iostream>
 #include <sstream>

--- a/D4StreamMarshaller.h
+++ b/D4StreamMarshaller.h
@@ -56,6 +56,7 @@
 namespace libdap {
 
 class Vector;
+class MarshallerThread;
 
 /** @brief Marshaller that knows how to marshal/serialize dap data objects
  * to a C++ iostream using DAP4's receiver-makes-right scheme. This code
@@ -80,6 +81,7 @@ private:
 
     Crc32 d_checksum;
 
+    MarshallerThread *tm;
 
     // These are private so they won't ever get used.
     D4StreamMarshaller();

--- a/XDRStreamMarshaller.cc
+++ b/XDRStreamMarshaller.cc
@@ -63,7 +63,7 @@ using namespace std;
 namespace libdap {
 
 char *XDRStreamMarshaller::d_buf = 0;
-#define XDR_DAP_BUFF_SIZE 256
+static const int XDR_DAP_BUFF_SIZE=256;
 
 
 /** Build an instance of XDRStreamMarshaller. Bind the C++ stream out to this

--- a/XDRStreamMarshaller.h
+++ b/XDRStreamMarshaller.h
@@ -68,7 +68,6 @@ private:
     void put_vector(char *val, unsigned int num, int width, Type type);
 
     friend class MarshallerTest;
-    friend class MarshallerThread;
 
 public:
     XDRStreamMarshaller(ostream &out); //, bool checksum = false, bool write_data = true) ;


### PR DESCRIPTION
That's about it...

I also fixed two 'issues' in the XDRStreamMarshaller code - one line each. They are not bugs but are minor improvements in readability.