### PR TITLE
type fix for getopt

### DIFF
--- a/unit-tests/D4FilterClauseTest.cc
+++ b/unit-tests/D4FilterClauseTest.cc
@@ -566,7 +566,7 @@ int main(int argc, char*argv[]) {
     runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
 
     GetOpt getopt(argc, argv, "d");
-    char option_char;
+    int option_char;
 
     while ((option_char = getopt()) != EOF)
         switch (option_char) {


### PR DESCRIPTION
The getopt() function uses int as return type and using char for a variable storing
teh return value makes problem on platform where char is unsgined by default.

http://www.arm.linux.org.uk/docs/faqs/signedchar.php

Fix by Orion Poplawski <orion[at]cora.nwra.com> for https://bugzilla.redhat.com/show_bug.cgi?id=1366787