### PR TITLE
Fix fir D4Group::ptr_duplicate(). It was not returning BaseType*

### DIFF
--- a/D4Group.cc
+++ b/D4Group.cc
@@ -95,7 +95,8 @@ void D4Group::m_duplicate(const D4Group &g)
     // groups
     groupsCIter i = g.d_groups.begin();
     while(i != g.d_groups.end()) {
-        D4Group *g = (*i++)->ptr_duplicate();
+        // Only D4Groups are in the d_groups container.
+        D4Group *g = static_cast<D4Group*>((*i++)->ptr_duplicate());
         add_group_nocopy(g);
     }
 
@@ -147,7 +148,12 @@ D4Group::~D4Group()
         delete *i++;
 }
 
+#if 0
 D4Group *
+
+// I think this was a mistake. jhrg 11/17/16
+#endif
+BaseType *
 D4Group::ptr_duplicate()
 {
     return new D4Group(*this);

--- a/D4Group.h
+++ b/D4Group.h
@@ -74,7 +74,9 @@ public:
     virtual ~D4Group();
 
     D4Group &operator=(const D4Group &rhs);
-    virtual D4Group *ptr_duplicate();
+
+    // This method returned a D4Group * previously. jhrg 11/17/16
+    virtual BaseType *ptr_duplicate();
 
     /// Get the dimensions defined for this Group
     D4Dimensions *dims() {

--- a/DMR.cc
+++ b/DMR.cc
@@ -95,7 +95,8 @@ DMR::m_duplicate(const DMR &dmr)
     d_max_response_size = dmr.d_max_response_size;
 
     // Deep copy, using ptr_duplicate()
-    d_root = dmr.d_root->ptr_duplicate();
+    // d_root can only be a D4Group, so the thing returned by ptr_duplicate() must be a D4Group.
+    d_root = static_cast<D4Group*>(dmr.d_root->ptr_duplicate());
     DBG(cerr << "dmr.d_root: " << dmr.d_root << endl);
     DBG(cerr << "d_root (from ptr_dup(): " << d_root << endl);
 


### PR DESCRIPTION
Instead, it returned D4Group. There may have been a good reason,
But I think consistency is better. ...maybe