### PR TITLE
Hyrax 400

### DIFF
--- a/D4Group.cc
+++ b/D4Group.cc
@@ -24,7 +24,7 @@
 
 #include "config.h"
 
-//#define DODS_DEBUG
+#define DODS_DEBUG
 
 #include <iostream>
 #include <sstream>
@@ -518,7 +518,7 @@ D4Group::serialize(D4StreamMarshaller &m, DMR &dmr, /*ConstraintEvaluator &eval,
 
     groupsIter g = d_groups.begin();
     while (g != d_groups.end())
-        (*g++)->serialize(m, dmr, /*eval,*/ filter);
+        (*g++)->serialize(m, dmr, filter);
 
     // Specialize how the top-level variables in any Group are sent; include
     // a checksum for them. A subset operation might make an interior set of
@@ -533,7 +533,7 @@ D4Group::serialize(D4StreamMarshaller &m, DMR &dmr, /*ConstraintEvaluator &eval,
 			m.reset_checksum();
 
 	        DBG(cerr << "Serializing variable " << (*i)->type_name() << " " << (*i)->name() << endl);
-			(*i)->serialize(m, dmr, /*eval,*/ filter);
+			(*i)->serialize(m, dmr, filter);
 
 			DBG(cerr << "Wrote CRC32: " << m.get_checksum() << " for " << (*i)->name() << endl);
 			m.put_checksum();

--- a/D4Group.cc
+++ b/D4Group.cc
@@ -24,7 +24,7 @@
 
 #include "config.h"
 
-#define DODS_DEBUG
+//#define DODS_DEBUG
 
 #include <iostream>
 #include <sstream>

--- a/Vector.cc
+++ b/Vector.cc
@@ -578,8 +578,9 @@ void Vector::vec_resize(int l)
     if (m_is_cardinal_type())
         throw InternalErr(__FILE__, __LINE__, "Vector::vec_resize() is applicable to compound types only");
 
-    d_compound_buf.resize((l > 0) ? l : 0, 0); // Fill with NULLs
-    d_capacity = l; // capacity in terms of number of elements.
+    // Use resize() since other parts of the code use operator[].
+    d_compound_buf.resize((l > 0) ? l : 0); // Fill with NULLs
+    d_capacity = d_compound_buf.capacity(); // capacity in terms of number of elements.
 }
 
 /** @brief read data into a variable for later use
@@ -1359,10 +1360,15 @@ void Vector::set_vec_nocopy(unsigned int i, BaseType * val)
     if (val->type() != d_proto->type())
         throw InternalErr(__FILE__, __LINE__, "invalid data: type of incoming object does not match *this* vector type.");
 
-    if (i >= d_compound_buf.capacity())
+    // This doesn't seem to work. FIXME jhrg 5/18/17
+    if (i >= d_compound_buf.capacity()) {
+        DBG(cerr << __func__ << " enlarging d_compound_buf by 10" << endl);
         vec_resize(i + 10);
+    }
 
     d_compound_buf[i] = val;
+
+    DBG(cerr << __func__ << " d_compound_buf[" << i << "] " << d_compound_buf[i] << endl);
 }
 
 /**

--- a/tests/TestArray.cc
+++ b/tests/TestArray.cc
@@ -47,7 +47,7 @@
 #include <process.h>
 #endif
 
-//#define DODS_DEBUG
+#define DODS_DEBUG
 
 #include "util.h"
 #include "debug.h"
@@ -536,11 +536,13 @@ bool TestArray::read()
 
     case dods_opaque_c:
     case dods_structure_c:
-        cerr << __func__ << " array_len: " << array_len << endl;
+        DBG(cerr << __func__ << " array_len: " << array_len << endl);
+        // Hyrax-400: uncomment this 'fixes' the bug, but why? jhrg 5/18/17
+        // vec_resize(array_len);
         for (unsigned i = 0; i < array_len; ++i) {
             // Copy the prototype and read a value into it
             BaseType *elem = var()->ptr_duplicate();
-            cerr << __func__ << " elem: " << elem << " [" << i << "]" << endl;
+            DBG(cerr << __func__ << " elem: " << elem << " [" << i << "]" << endl);
             elem->read();
             // Load the new value into this object's array
             set_vec_nocopy(i, elem);   // Use set_vec_nocopy() TODO (and below)
@@ -553,11 +555,9 @@ bool TestArray::read()
         if (!is_dap4()) throw InternalErr(__FILE__, __LINE__, "Bad data type");
 
         for (unsigned i = 0; i < array_len; ++i) {
-            // Copy the prototype and read a value into it
-            BaseType *elem = var()->ptr_duplicate();
-            //elem->read();
-            // Load the new value into this object's array
-            set_vec(i, elem);
+            // BaseType *elem = var()->ptr_duplicate();
+            // Load the new BaseType (a D4Sequence) into the array element
+            set_vec_nocopy(i, /*elem*/ var()->ptr_duplicate());
         }
 
         break;

--- a/tests/TestArray.cc
+++ b/tests/TestArray.cc
@@ -536,12 +536,14 @@ bool TestArray::read()
 
     case dods_opaque_c:
     case dods_structure_c:
+        cerr << __func__ << " array_len: " << array_len << endl;
         for (unsigned i = 0; i < array_len; ++i) {
             // Copy the prototype and read a value into it
             BaseType *elem = var()->ptr_duplicate();
+            cerr << __func__ << " elem: " << elem << " [" << i << "]" << endl;
             elem->read();
             // Load the new value into this object's array
-            set_vec(i, elem);
+            set_vec_nocopy(i, elem);   // Use set_vec_nocopy() TODO (and below)
         }
         set_read_p(true);
         break;

--- a/tests/TestArray.cc
+++ b/tests/TestArray.cc
@@ -47,7 +47,7 @@
 #include <process.h>
 #endif
 
-#define DODS_DEBUG
+//#define DODS_DEBUG
 
 #include "util.h"
 #include "debug.h"
@@ -536,13 +536,10 @@ bool TestArray::read()
 
     case dods_opaque_c:
     case dods_structure_c:
-        DBG(cerr << __func__ << " array_len: " << array_len << endl);
-        // Hyrax-400: uncomment this 'fixes' the bug, but why? jhrg 5/18/17
-        // vec_resize(array_len);
+        vec_resize(array_len);
         for (unsigned i = 0; i < array_len; ++i) {
             // Copy the prototype and read a value into it
             BaseType *elem = var()->ptr_duplicate();
-            DBG(cerr << __func__ << " elem: " << elem << " [" << i << "]" << endl);
             elem->read();
             // Load the new value into this object's array
             set_vec_nocopy(i, elem);   // Use set_vec_nocopy() TODO (and below)
@@ -554,10 +551,10 @@ bool TestArray::read()
         // No sequence arrays in DAP2
         if (!is_dap4()) throw InternalErr(__FILE__, __LINE__, "Bad data type");
 
+        vec_resize(array_len);
         for (unsigned i = 0; i < array_len; ++i) {
-            // BaseType *elem = var()->ptr_duplicate();
             // Load the new BaseType (a D4Sequence) into the array element
-            set_vec_nocopy(i, /*elem*/ var()->ptr_duplicate());
+            set_vec_nocopy(i, var()->ptr_duplicate());
         }
 
         break;


### PR DESCRIPTION
Fixes a bug... 

Vector::vec_resize() was broken; successive calls would result in lost data. The fix is to use size() when determining when to call std::vector::resize() and not capacity()