### PR TITLE
Fixed the libcrypto link error on OSX 10.13

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,7 +61,7 @@ libdap_la_LIBADD = $(XML2_LIBS) $(PTHREAD_LIBS) gl/libgnu.la d4_ce/libd4_ce_pars
 d4_function/libd4_function_parser.la libparsers.la
 
 if DAP4_DEFINED
-    libdap_la_LIBADD += -lcrypto 
+    libdap_la_LIBADD += $(CRYPTO_LIBS)
 endif
 
 libdapclient_la_SOURCES = $(CLIENT_SRC) 

--- a/configure.ac
+++ b/configure.ac
@@ -303,6 +303,11 @@ AC_CHECK_LIB([uuid], [uuid_generate],
 	[UUID_LIBS=""])
 AC_SUBST([UUID_LIBS])
 
+AC_CHECK_LIB([crypto], [OpenSSL_add_all_algorithms], 
+	[CRYPTO_LIBS="-lcrypto"],
+	[CRYPTO_LIBS=""])
+AC_SUBST([CRYPTO_LIBS])
+
 AM_PATH_CPPUNIT(1.12.0,
 	[AM_CONDITIONAL([CPPUNIT], [true])],
 	[
@@ -336,7 +341,7 @@ AS_IF([test x$enable_dap4 = xyes], [
 
 AC_ARG_ENABLE([developer],
 	[AS_HELP_STRING([--enable-developer],
-				    [Build a debug (-g3 -O0) version of this code and include assert() calls in the code (default is no)])],
+		    [Build a debug (-g3 -O0) version of this code and include assert() calls in the code (default is no)])],
     [build_developer=${enableval}],
     [build_developer=no])
 


### PR DESCRIPTION
on OSX 10.13 there is no longer a libcrypto. We were linking with that for DAP4's CRC32 code. I think we still need it on linux. Here's a fix that works on OSX 10.13. This pull request will test if it works on Ubuntu...