### PR TITLE
Fixed a memory error that could be triggered by passing bad XML to ...

### DIFF
--- a/D4ParserSax2.cc
+++ b/D4ParserSax2.cc
@@ -206,7 +206,7 @@ bool D4ParserSax2::process_dimension_def(const char *name, const xmlChar **attrs
         dim_def()->set_size(xml_attrs["size"].value);
     }
     catch (Error &e) {
-        dmr_error(this, e.get_error_message().c_str());
+        dmr_error(this, "%s", e.get_error_message().c_str());
         return false;
     }
 


### PR DESCRIPTION
the DAP4 DMR parser.

vsnprintf() could be called with a tainted format string.