### PR TITLE
The DDS::print_xml and print_xml_writer now only return a '3.2' DDX

### DIFF
--- a/DDS.cc
+++ b/DDS.cc
@@ -89,14 +89,9 @@
 #include "escaping.h"
 
 /**
- * ############################################################################################
- * ############################################################################################
- * ############################################################################################
  * DapXmlNamespaces
  *
- * FIXME Replace all usages of the following variable with calls to DapXmlNamespaces
- * TODO  Replace all usages of the following variable with calls to DapXmlNamespaces
- *
+ * @todo Replace all usages of the following variable with calls to DapXmlNamespaces
  */
 const string c_xml_xsi = "http://www.w3.org/2001/XMLSchema-instance";
 const string c_xml_namespace = "http://www.w3.org/XML/1998/namespace";
@@ -114,13 +109,6 @@ const string c_dap40_namespace = "http://xml.opendap.org/ns/DAP/4.0#";
 const string c_dap_20_n_sl = c_dap20_namespace + " " + c_default_dap20_schema_location;
 const string c_dap_32_n_sl = c_dap32_namespace + " " + c_default_dap32_schema_location;
 const string c_dap_40_n_sl = c_dap40_namespace + " " + c_default_dap40_schema_location;
-/**
- *
- * DapXmlNamespaces
- * ############################################################################################
- * ############################################################################################
- * ############################################################################################
- */
 
 /// Name given to a container for orphaned top-level attributes.
 /// These can show up when a DAS is built from a DMR because DAP4
@@ -626,11 +614,6 @@ DDS::add_var_nocopy(BaseType *bt)
 {
     if (!bt)
         throw InternalErr(__FILE__, __LINE__, "Trying to add a BaseType object with a NULL pointer.");
-#if 0
-    //FIXME There's no longer a DAP2 and DAP4 DDS
-    if (bt->is_dap4_only_type())
-        throw InternalErr(__FILE__, __LINE__, "Attempt to add a DAP4 type to a DAP2 DDS.");
-#endif
 
     DBG2(cerr << "In DDS::add_var(), bt's address is: " << bt << endl);
 
@@ -1066,7 +1049,7 @@ DDS::print(ostream &out)
  * @return true if the table contains a scalar- or vector-valued attribute,
  * otherwise false.
  */
-static bool
+bool
 has_dap2_attributes(AttrTable &a)
 {
     for (AttrTable::Attr_iter i = a.attr_begin(), e = a.attr_end(); i != e; ++i) {
@@ -1106,7 +1089,7 @@ has_dap2_attributes(AttrTable &a)
  * @return True if any of the variable's descendants have attributes,
  * otherwise false.
  */
-static bool
+bool
 has_dap2_attributes(BaseType *btp)
 {
     if (btp->get_attr_table().get_size() && has_dap2_attributes(btp->get_attr_table())) {
@@ -1400,7 +1383,7 @@ DDS::print_xml(FILE *out, bool constrained, const string &blob)
 }
 
 /** Print an XML representation of this DDS. This method is used to generate
-    the part of the DDX response. The \c Dataset tag is \e not written by
+    the DDX response. The \c Dataset tag is \e not written by
     this code. The caller of this method must handle writing that and
     including the \c dataBLOB tag.
 
@@ -1451,75 +1434,117 @@ DDS::print_xml_writer(ostream &out, bool constrained, const string &blob)
 {
     XMLWriter xml("    ");
 
+    // this is the old version of this method. It produced different output for
+    // different version of DAP. We stopped using version numbers and use different
+    // web api calls (DMR, DAP for DAP4 and DAS, DDS and DODS for DAP2) so the
+    // dap version numbers are old and should not be used. There also seems to
+    // be a bug where these version numbers change 'randomly' but which doesn't
+    // show up in testing (or with valgrind or asan). jhrg 9/10/18
+#if 0
     // Stamp and repeat for these sections; trying to economize is makes it
     // even more confusing
     if (get_dap_major() >= 4) {
         if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "Group") < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write Group element");
+        throw InternalErr(__FILE__, __LINE__, "Could not write Group element");
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "name", (const xmlChar*)d_name.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for name");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for name");
 
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "dapVersion", (const xmlChar*)get_dap_version().c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for dapVersion");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for dapVersion");
 
         if (!get_request_xml_base().empty()) {
             if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:xml", (const xmlChar*)c_xml_namespace.c_str()) < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xml");
+            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xml");
 
             if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xml:base", (const xmlChar*)get_request_xml_base().c_str()) < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xml:base");
+            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xml:base");
         }
         if (!get_namespace().empty()) {
             if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns", (const xmlChar*)get_namespace().c_str()) < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns");
+            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns");
         }
     }
     else if (get_dap_major() == 3 && get_dap_minor() >= 2) {
         if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "Dataset") < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write Dataset element");
+        throw InternalErr(__FILE__, __LINE__, "Could not write Dataset element");
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "name", (const xmlChar*)d_name.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for name");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for name");
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:xsi", (const xmlChar*)"http://www.w3.org/2001/XMLSchema-instance") < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xsi");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xsi");
 
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xsi:schemaLocation", (const xmlChar*)c_dap_32_n_sl.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:schemaLocation");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:schemaLocation");
 
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:grddl", (const xmlChar*)"http://www.w3.org/2003/g/data-view#") < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:grddl");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:grddl");
 
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "grddl:transformation", (const xmlChar*)grddl_transformation_dap32.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:transformation");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:transformation");
 
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns", (const xmlChar*)c_dap32_namespace.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns");
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:dap", (const xmlChar*)c_dap32_namespace.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:dap");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:dap");
 
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "dapVersion", (const xmlChar*)"3.2") < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for dapVersion");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for dapVersion");
 
         if (!get_request_xml_base().empty()) {
             if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:xml", (const xmlChar*)c_xml_namespace.c_str()) < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xml");
+            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xml");
 
             if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xml:base", (const xmlChar*)get_request_xml_base().c_str()) < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xml:base");
+            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xml:base");
         }
     }
     else { // dap2
         if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "Dataset") < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write Dataset element");
+        throw InternalErr(__FILE__, __LINE__, "Could not write Dataset element");
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "name", (const xmlChar*)d_name.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:xsi", (const xmlChar*)"http://www.w3.org/2001/XMLSchema-instance") < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xsi");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xsi");
 
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns", (const xmlChar*)c_dap20_namespace.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns");
 
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xsi:schemaLocation", (const xmlChar*)c_dap_20_n_sl.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:schemaLocation");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:schemaLocation");
+    }
+#endif
+
+    // This is the 'DAP 3.2' DDX response - now the only response libdap will return.
+    // jhrg 9/10/18
+    if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "Dataset") < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write Dataset element");
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "name", (const xmlChar*)d_name.c_str()) < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for name");
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:xsi", (const xmlChar*)"http://www.w3.org/2001/XMLSchema-instance") < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xsi");
+
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xsi:schemaLocation", (const xmlChar*)c_dap_32_n_sl.c_str()) < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:schemaLocation");
+
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:grddl", (const xmlChar*)"http://www.w3.org/2003/g/data-view#") < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:grddl");
+
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "grddl:transformation", (const xmlChar*)grddl_transformation_dap32.c_str()) < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:transformation");
+
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns", (const xmlChar*)c_dap32_namespace.c_str()) < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns");
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:dap", (const xmlChar*)c_dap32_namespace.c_str()) < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:dap");
+
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "dapVersion", (const xmlChar*)"3.2") < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for dapVersion");
+
+    if (!get_request_xml_base().empty()) {
+        if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:xml", (const xmlChar*)c_xml_namespace.c_str()) < 0)
+            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xml");
+
+        if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xml:base", (const xmlChar*)get_request_xml_base().c_str()) < 0)
+            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xml:base");
     }
 
     // Print the global attributes
@@ -1528,6 +1553,9 @@ DDS::print_xml_writer(ostream &out, bool constrained, const string &blob)
     // Print each variable
     for_each(var_begin(), var_end(), VariablePrintXMLWriter(xml, constrained));
 
+    // As above, this method now onl returns the DAP 3.2 version of the DDX response.
+    // jhrg 9/10/28
+#if 0
     // For DAP 3.2 and greater, use the new syntax and value. The 'blob' is
     // the CID of the MIME part that holds the data. For DAP2 (which includes
     // 3.0 and 3.1), the blob is an href. For DAP4, only write the CID if it's
@@ -1535,31 +1563,40 @@ DDS::print_xml_writer(ostream &out, bool constrained, const string &blob)
     if (get_dap_major() >= 4) {
         if (!blob.empty()) {
             if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "blob") < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not write blob element");
+            throw InternalErr(__FILE__, __LINE__, "Could not write blob element");
             string cid = "cid:" + blob;
             if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "href", (const xmlChar*) cid.c_str()) < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
+            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
             if (xmlTextWriterEndElement(xml.get_writer()) < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not end blob element");
+            throw InternalErr(__FILE__, __LINE__, "Could not end blob element");
         }
     }
     else if (get_dap_major() == 3 && get_dap_minor() >= 2) {
         if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "blob") < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write blob element");
+        throw InternalErr(__FILE__, __LINE__, "Could not write blob element");
         string cid = "cid:" + blob;
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "href", (const xmlChar*) cid.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
         if (xmlTextWriterEndElement(xml.get_writer()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not end blob element");
+        throw InternalErr(__FILE__, __LINE__, "Could not end blob element");
     }
     else { // dap2
         if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "dataBLOB") < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write dataBLOB element");
+        throw InternalErr(__FILE__, __LINE__, "Could not write dataBLOB element");
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "href", (const xmlChar*) "") < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
         if (xmlTextWriterEndElement(xml.get_writer()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Could not end dataBLOB element");
+        throw InternalErr(__FILE__, __LINE__, "Could not end dataBLOB element");
     }
+#endif
+
+    if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "blob") < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write blob element");
+    string cid = "cid:" + blob;
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "href", (const xmlChar*) cid.c_str()) < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
+    if (xmlTextWriterEndElement(xml.get_writer()) < 0)
+        throw InternalErr(__FILE__, __LINE__, "Could not end blob element");
 
     if (xmlTextWriterEndElement(xml.get_writer()) < 0)
         throw InternalErr(__FILE__, __LINE__, "Could not end Dataset element");
@@ -1568,8 +1605,9 @@ DDS::print_xml_writer(ostream &out, bool constrained, const string &blob)
 }
 
 /**
- * Print the DAP4 DMR object.
- * This method prints the DMR. If the dap version is not >= 4.0, it's an
+ * @brief Print the DAP4 DMR object using a DDS.
+ *
+ * This method prints the DMR from a DDS. If the dap version is not >= 4.0, it's an
  * error to call this method.
  *
  * @note Calling methods that print the DDS or DDX when get_dap_major()
@@ -1629,24 +1667,6 @@ DDS::print_dmr(ostream &out, bool constrained)
     // Print each variable
     for_each(var_begin(), var_end(), VariablePrintXMLWriter(xml, constrained));
 
-#if 0
-    // For DAP 3.2 and greater, use the new syntax and value. The 'blob' is
-    // the CID of the MIME part that holds the data. For DAP2 (which includes
-    // 3.0 and 3.1), the blob is an href. For DAP4, only write the CID if it's
-    // given.
-    if (get_dap_major() >= 4) {
-        if (!blob.empty()) {
-            if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "blob") < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not write blob element");
-            string cid = "cid:" + blob;
-            if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "href", (const xmlChar*) cid.c_str()) < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
-            if (xmlTextWriterEndElement(xml.get_writer()) < 0)
-                throw InternalErr(__FILE__, __LINE__, "Could not end blob element");
-        }
-    }
-#endif
-
     if (xmlTextWriterEndElement(xml.get_writer()) < 0)
         throw InternalErr(__FILE__, __LINE__, "Could not end the top-level Group element");
 
@@ -1705,8 +1725,6 @@ DDS::check_semantics(bool all)
 
     @return True if the named variable was found, false otherwise.
 
-    @todo This should throw an exception on error!!!
-
     @todo These methods that use the btp_stack to keep track of the path from
     the top of a dataset to a particular variable can be rewritten to use the
     parent field instead.
@@ -1717,16 +1735,25 @@ DDS::check_semantics(bool all)
 bool
 DDS::mark(const string &n, bool state)
 {
+#if 0
     // TODO use auto_ptr
     BaseType::btp_stack *s = new BaseType::btp_stack;
+#endif
+
+    auto_ptr<BaseType::btp_stack> s(new BaseType::btp_stack);
 
     DBG2(cerr << "DDS::mark: Looking for " << n << endl);
 
-    BaseType *variable = var(n, s);
+    BaseType *variable = var(n, s.get());
     if (!variable) {
+        throw Error(malformed_expr, "Could not find variable " + n);
+#if 0
         DBG2(cerr << "Could not find variable " << n << endl);
+#if 0
         delete s; s = 0;
+#endif
         return false;
+#endif
     }
     variable->set_send_p(state);
 
@@ -1742,16 +1769,17 @@ DDS::mark(const string &n, bool state)
 
         DBG2(cerr << "DDS::mark: Set variable " << s->top()->d_name()
                 << " (a " << s->top()->type_name() << ")" << endl);
-        // FIXME get_parent() hosed?
-#if 1
+
         string parent_name = (s->top()->get_parent()) ? s->top()->get_parent()->name(): "none";
         string parent_type = (s->top()->get_parent()) ? s->top()->get_parent()->type_name(): "none";
         DBG2(cerr << "DDS::mark: Parent variable " << parent_name << " (a " << parent_type << ")" << endl);
-#endif
+
         s->pop();
     }
 
-    delete s ; s = 0;
+#if 0
+    delete s; s = 0;
+#endif
 
     return true;
 }

--- a/DDS.h
+++ b/DDS.h
@@ -75,6 +75,9 @@
 namespace libdap
 {
 
+bool has_dap2_attributes(BaseType *btp);
+bool has_dap2_attributes(AttrTable &a);
+
 /** The DAP2 Data Descriptor Object (DDS) is a data structure used by
     the DAP2 software to describe datasets and subsets of those
     datasets.  The DDS may be thought of as the declarations for the

--- a/unit-tests/DDSTest.cc
+++ b/unit-tests/DDSTest.cc
@@ -162,7 +162,7 @@ public:
             das.parse((string) TEST_SRC_DIR + "/dds-testsuite/fnoc1.nc.das");
             dds1->transfer_attributes(&das);
 
-            DBG2(dds1->print_xml(cerr, false, ""));
+            DBG(dds1->print_xml(cerr, false, ""));
 
             AttrTable &at = dds1->get_attr_table();
             AttrTable::Attr_iter i = at.attr_begin();
@@ -183,7 +183,7 @@ public:
             das.parse((string) TEST_SRC_DIR + "/dds-testsuite/3B42.980909.5.hacked.HDF.das");
             dds2->transfer_attributes(&das);
 
-            DBG2(dds2->print_xml(cerr, false, ""));
+            DBG(dds2->print_xml(cerr, false, ""));
 
             AttrTable &at = dds2->get_attr_table();
             AttrTable::Attr_iter i = at.attr_begin();
@@ -222,10 +222,10 @@ public:
             dds2->parse((string) TEST_SRC_DIR + "/dds-testsuite/test.19b");
             ostringstream oss;
             dds2->print_xml_writer(oss, false, "http://localhost/dods/test.xyz");
-            DBG2(cerr << "Printed DDX: " << oss.str() << endl);
+            DBG(cerr << "Printed DDX: " << oss.str() << endl);
 
             string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19b.xml");
-            DBG2(cerr << "The baseline: " << baseline << endl);
+            DBG(cerr << "The baseline: " << baseline << endl);
 
             CPPUNIT_ASSERT(baseline == oss.str());
         }
@@ -246,10 +246,10 @@ public:
         ostringstream oss;
         dds2->print_xml_writer(oss, false, "http://localhost/dods/test.xyz");
 
-        DBG2(cerr << oss.str() << endl);
+        DBG(cerr << oss.str() << endl);
 
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19c.xml");
-        DBG2(cerr << baseline << endl);
+        DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }
 
@@ -264,10 +264,10 @@ public:
         ostringstream oss;
         dds2->print_xml_writer(oss, false, "http://localhost/dods/test.xyz");
 
-        DBG2(cerr << oss.str() << endl);
+        DBG(cerr << oss.str() << endl);
 
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19d.xml");
-        DBG2(cerr << baseline << endl);
+        DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }
 
@@ -284,10 +284,10 @@ public:
         ostringstream oss;
         dds2->print_xml_writer(oss, false, "http://localhost/dods/test.xyz");
 
-        DBG2(cerr << oss.str() << endl);
+        DBG(cerr << oss.str() << endl);
 
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19d1.xml");
-        DBG2(cerr << baseline << endl);
+        DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }
 
@@ -307,7 +307,7 @@ public:
         DBG(cerr << oss.str() << endl);
 
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19e.xml");
-        DBG2(cerr << baseline << endl);
+        DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }
 
@@ -367,7 +367,7 @@ public:
         DBG(cerr << oss.str() << endl);
 
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19f1.xml");
-        DBG2(cerr << baseline << endl);
+        DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }
 
@@ -385,7 +385,7 @@ public:
         DBG(cerr << oss.str() << endl);
 
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19b6.xml");
-        DBG2(cerr << baseline << endl);
+        DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }
 
@@ -413,7 +413,7 @@ public:
         DBG(cerr << oss.str() << endl);
 
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19g.xml");
-        DBG2(cerr << baseline << endl);
+        DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }
 

--- a/unit-tests/dds-testsuite/test.19b.xml
+++ b/unit-tests/dds-testsuite/test.19b.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<Dataset name="test.19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+<Dataset name="test.19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xml.opendap.org/ns/DAP/3.2# http://xml.opendap.org/dap/dap3.2.xsd" xmlns:grddl="http://www.w3.org/2003/g/data-view#" grddl:transformation="http://xml.opendap.org/transforms/ddxToRdfTriples.xsl" xmlns="http://xml.opendap.org/ns/DAP/3.2#" xmlns:dap="http://xml.opendap.org/ns/DAP/3.2#" dapVersion="3.2">
     <Int32 name="a"/>
     <Array name="b#c">
         <Int32/>
@@ -16,5 +16,5 @@
             <dimension size="512"/>
         </Map>
     </Grid>
-    <dataBLOB href=""/>
+    <blob href="cid:http://localhost/dods/test.xyz"/>
 </Dataset>

--- a/unit-tests/dds-testsuite/test.19b6.xml
+++ b/unit-tests/dds-testsuite/test.19b6.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<Dataset name="test.19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+<Dataset name="test.19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xml.opendap.org/ns/DAP/3.2# http://xml.opendap.org/dap/dap3.2.xsd" xmlns:grddl="http://www.w3.org/2003/g/data-view#" grddl:transformation="http://xml.opendap.org/transforms/ddxToRdfTriples.xsl" xmlns="http://xml.opendap.org/ns/DAP/3.2#" xmlns:dap="http://xml.opendap.org/ns/DAP/3.2#" dapVersion="3.2">
     <Attribute name="NC_GLOBAL" type="Container">
         <Attribute name="long_name" type="String">
             <value>Attribute merge test</value>
@@ -49,5 +49,5 @@
             <dimension size="512"/>
         </Map>
     </Grid>
-    <dataBLOB href=""/>
+    <blob href="cid:http://localhost/dods/test.xyz"/>
 </Dataset>

--- a/unit-tests/dds-testsuite/test.19c.xml
+++ b/unit-tests/dds-testsuite/test.19c.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<Dataset name="test.19c" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+<Dataset name="test.19c" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xml.opendap.org/ns/DAP/3.2# http://xml.opendap.org/dap/dap3.2.xsd" xmlns:grddl="http://www.w3.org/2003/g/data-view#" grddl:transformation="http://xml.opendap.org/transforms/ddxToRdfTriples.xsl" xmlns="http://xml.opendap.org/ns/DAP/3.2#" xmlns:dap="http://xml.opendap.org/ns/DAP/3.2#" dapVersion="3.2">
     <Attribute name="NC_GLOBAL" type="Container">
         <Attribute name="long_name" type="String">
             <value>Attribute merge test</value>
@@ -13,5 +13,5 @@
         </Attribute>
     </Attribute>
     <Int32 name="a"/>
-    <dataBLOB href=""/>
+    <blob href="cid:http://localhost/dods/test.xyz"/>
 </Dataset>

--- a/unit-tests/dds-testsuite/test.19d.xml
+++ b/unit-tests/dds-testsuite/test.19d.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<Dataset name="test.19d" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+<Dataset name="test.19d" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xml.opendap.org/ns/DAP/3.2# http://xml.opendap.org/dap/dap3.2.xsd" xmlns:grddl="http://www.w3.org/2003/g/data-view#" grddl:transformation="http://xml.opendap.org/transforms/ddxToRdfTriples.xsl" xmlns="http://xml.opendap.org/ns/DAP/3.2#" xmlns:dap="http://xml.opendap.org/ns/DAP/3.2#" dapVersion="3.2">
     <Array name="b#c">
         <Attribute name="long_name" type="String">
             <value>b pound c</value>
@@ -7,5 +7,5 @@
         <Int32/>
         <dimension size="10"/>
     </Array>
-    <dataBLOB href=""/>
+    <blob href="cid:http://localhost/dods/test.xyz"/>
 </Dataset>

--- a/unit-tests/dds-testsuite/test.19e.xml
+++ b/unit-tests/dds-testsuite/test.19e.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<Dataset name="test.19e" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+<Dataset name="test.19e" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xml.opendap.org/ns/DAP/3.2# http://xml.opendap.org/dap/dap3.2.xsd" xmlns:grddl="http://www.w3.org/2003/g/data-view#" grddl:transformation="http://xml.opendap.org/transforms/ddxToRdfTriples.xsl" xmlns="http://xml.opendap.org/ns/DAP/3.2#" xmlns:dap="http://xml.opendap.org/ns/DAP/3.2#" dapVersion="3.2">
     <Float64 name="c d">
         <Attribute name="long_name" type="String">
             <value>c d with a WWW escape sequence</value>
@@ -13,5 +13,5 @@
             </Attribute>
         </Attribute>
     </Float64>
-    <dataBLOB href=""/>
+    <blob href="cid:http://localhost/dods/test.xyz"/>
 </Dataset>

--- a/unit-tests/dds-testsuite/test.19f.xml
+++ b/unit-tests/dds-testsuite/test.19f.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<Dataset name="test.19f" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+<Dataset name="test.19f" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xml.opendap.org/ns/DAP/3.2# http://xml.opendap.org/dap/dap3.2.xsd" xmlns:grddl="http://www.w3.org/2003/g/data-view#" grddl:transformation="http://xml.opendap.org/transforms/ddxToRdfTriples.xsl" xmlns="http://xml.opendap.org/ns/DAP/3.2#" xmlns:dap="http://xml.opendap.org/ns/DAP/3.2#" dapVersion="3.2">
     <Grid name="huh">
         <Attribute name="long_name" type="String">
             <value>The Grid huh</value>
@@ -16,5 +16,5 @@
             <dimension size="512"/>
         </Map>
     </Grid>
-    <dataBLOB href=""/>
+    <blob href="cid:http://localhost/dods/test.xyz"/>
 </Dataset>


### PR DESCRIPTION
There is an issue in the BES where, for unknown reasons, a DAP2 or
DAP3.2 DDX will be returned. The DDX response should only be '3.2'.
Since there is no used for DAP2 DDX, I've removed it. This doesn't
address the underlying problem, however (why the version number in
the DDS object do not match those set by the BES's client).