### PR TITLE
DDX fix 2

### DIFF
--- a/DDS.cc
+++ b/DDS.cc
@@ -88,6 +88,9 @@
 
 #include "escaping.h"
 
+#define DAP2_DDX 1
+#undef DAP3_2_DDX
+
 /**
  * DapXmlNamespaces
  *
@@ -1513,6 +1516,20 @@ DDS::print_xml_writer(ostream &out, bool constrained, const string &blob)
     }
 #endif
 
+#if DAP2_DDX
+    if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "Dataset") < 0)
+    throw InternalErr(__FILE__, __LINE__, "Could not write Dataset element");
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "name", (const xmlChar*)d_name.c_str()) < 0)
+    throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns:xsi", (const xmlChar*)"http://www.w3.org/2001/XMLSchema-instance") < 0)
+    throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:xsi");
+
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xmlns", (const xmlChar*)c_dap20_namespace.c_str()) < 0)
+    throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns");
+
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xsi:schemaLocation", (const xmlChar*)c_dap_20_n_sl.c_str()) < 0)
+    throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xmlns:schemaLocation");
+#elif DAP3_2_DDX
     // This is the 'DAP 3.2' DDX response - now the only response libdap will return.
     // jhrg 9/10/18
     if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "Dataset") < 0)
@@ -1546,6 +1563,9 @@ DDS::print_xml_writer(ostream &out, bool constrained, const string &blob)
         if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "xml:base", (const xmlChar*)get_request_xml_base().c_str()) < 0)
             throw InternalErr(__FILE__, __LINE__, "Could not write attribute for xml:base");
     }
+#else
+#error Must define DAP2_DDX or DAP3_2_DDX
+#endif
 
     // Print the global attributes
     d_attr.print_xml_writer(xml);
@@ -1590,6 +1610,14 @@ DDS::print_xml_writer(ostream &out, bool constrained, const string &blob)
     }
 #endif
 
+#if DAP2_DDX
+    if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "dataBLOB") < 0)
+    throw InternalErr(__FILE__, __LINE__, "Could not write dataBLOB element");
+    if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "href", (const xmlChar*) "") < 0)
+    throw InternalErr(__FILE__, __LINE__, "Could not write attribute for d_name");
+    if (xmlTextWriterEndElement(xml.get_writer()) < 0)
+    throw InternalErr(__FILE__, __LINE__, "Could not end dataBLOB element");
+#elif DAP3_2_DDX
     if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "blob") < 0)
         throw InternalErr(__FILE__, __LINE__, "Could not write blob element");
     string cid = "cid:" + blob;
@@ -1600,6 +1628,9 @@ DDS::print_xml_writer(ostream &out, bool constrained, const string &blob)
 
     if (xmlTextWriterEndElement(xml.get_writer()) < 0)
         throw InternalErr(__FILE__, __LINE__, "Could not end Dataset element");
+#else
+#error Must define DAP2_DDX or DAP3_2_DDX
+#endif
 
     out << xml.get_doc();// << ends;// << endl;
 }

--- a/DDS.cc
+++ b/DDS.cc
@@ -88,9 +88,6 @@
 
 #include "escaping.h"
 
-#define DAP2_DDX 1
-#undef DAP3_2_DDX
-
 /**
  * DapXmlNamespaces
  *

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,14 @@ AC_DEFINE_UNQUOTED(CVER, "$PACKAGE_VERSION", [Client version number])
 AC_DEFINE_UNQUOTED(DVR, "libdap/$PACKAGE_VERSION", [Client name and version combined])
 AC_SUBST(DVR)
 
+dnl Use one of these two blocks to build a DAP2 or DAP 3.2 DDX
+AC_DEFINE(DAP2_DDX, 1, [Build the DAP 2 version of the DDX])
+AC_SUBST(DAP2_DDX)
+dnl
+dnl AC_DEFINE(DAP3_2_DDX, 1, [Build the DAP 3.2 version of the DDX])
+dnl AC_SUBST(DAP3_2_DDX)
+
+
 PACKAGE_MAJOR_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$@\1@'`
 PACKAGE_MINOR_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$@\2@'`
 PACKAGE_SUBMINOR_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$@\3@'`

--- a/configure.ac
+++ b/configure.ac
@@ -22,11 +22,10 @@ AC_DEFINE_UNQUOTED(DVR, "libdap/$PACKAGE_VERSION", [Client name and version comb
 AC_SUBST(DVR)
 
 dnl Use one of these two blocks to build a DAP2 or DAP 3.2 DDX
-AC_DEFINE(DAP2_DDX, 1, [Build the DAP 2 version of the DDX])
-AC_SUBST(DAP2_DDX)
-dnl
-dnl AC_DEFINE(DAP3_2_DDX, 1, [Build the DAP 3.2 version of the DDX])
-dnl AC_SUBST(DAP3_2_DDX)
+dnl AC_DEFINE(DAP2_DDX, 1, [Build the DAP 2 version of the DDX])
+dnl AC_SUBST(DAP2_DDX)
+AC_DEFINE(DAP3_2_DDX, 1, [Build the DAP 3.2 version of the DDX])
+AC_SUBST(DAP3_2_DDX)
 
 
 PACKAGE_MAJOR_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$@\1@'`

--- a/unit-tests/DDSTest.cc
+++ b/unit-tests/DDSTest.cc
@@ -224,7 +224,11 @@ public:
             dds2->print_xml_writer(oss, false, "http://localhost/dods/test.xyz");
             DBG(cerr << "Printed DDX: " << oss.str() << endl);
 
+#if DAP2_DDX
+            string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19b.dap2.xml");
+#else
             string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19b.xml");
+#endif
             DBG(cerr << "The baseline: " << baseline << endl);
 
             CPPUNIT_ASSERT(baseline == oss.str());
@@ -248,7 +252,11 @@ public:
 
         DBG(cerr << oss.str() << endl);
 
+#if DAP2_DDX
+        string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19c.dap2.xml");
+#else
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19c.xml");
+#endif
         DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }
@@ -266,7 +274,12 @@ public:
 
         DBG(cerr << oss.str() << endl);
 
+#if DAP2_DDX
+        string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19d.dap2.xml");
+#else
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19d.xml");
+#endif
+
         DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }
@@ -306,7 +319,11 @@ public:
 
         DBG(cerr << oss.str() << endl);
 
+#if DAP2_DDX
+        string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19e.dap2.xml");
+#else
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19e.xml");
+#endif
         DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }
@@ -318,7 +335,12 @@ public:
         DAS das;
         string das_file((string) TEST_SRC_DIR + "/dds-testsuite/test.19f.das");
         das.parse(das_file);
+
+#if DAP2_DDX
+        string baseline_file((string) TEST_SRC_DIR + "/dds-testsuite/test.19f.dap2.xml");
+#else
         string baseline_file((string) TEST_SRC_DIR + "/dds-testsuite/test.19f.xml");
+#endif
         string baseline = read_test_baseline(baseline_file);
 
         try {
@@ -384,7 +406,12 @@ public:
 
         DBG(cerr << oss.str() << endl);
 
+#if DAP2_DDX
+        string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19b6.dap2.xml");
+#else
         string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/test.19b6.xml");
+#endif
+
         DBG(cerr << baseline << endl);
         CPPUNIT_ASSERT(baseline == oss.str());
     }

--- a/unit-tests/dds-testsuite/test.19b.dap2.xml
+++ b/unit-tests/dds-testsuite/test.19b.dap2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset name="test.19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+    <Int32 name="a"/>
+    <Array name="b#c">
+        <Int32/>
+        <dimension size="10"/>
+    </Array>
+    <Float64 name="c d"/>
+    <Grid name="huh">
+        <Array name="Image#data">
+            <Byte/>
+            <dimension size="512"/>
+        </Array>
+        <Map name="colors">
+            <String/>
+            <dimension size="512"/>
+        </Map>
+    </Grid>
+    <dataBLOB href=""/>
+</Dataset>

--- a/unit-tests/dds-testsuite/test.19b6.dap2.xml
+++ b/unit-tests/dds-testsuite/test.19b6.dap2.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset name="test.19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+    <Attribute name="NC_GLOBAL" type="Container">
+        <Attribute name="long_name" type="String">
+            <value>Attribute merge test</value>
+        </Attribute>
+        <Attribute name="primes" type="Int32">
+            <value>2</value>
+            <value>3</value>
+            <value>5</value>
+            <value>7</value>
+            <value>11</value>
+        </Attribute>
+    </Attribute>
+    <Int32 name="a"/>
+    <Array name="b#c">
+        <Attribute name="long_name" type="String">
+            <value>b pound c</value>
+        </Attribute>
+        <Int32/>
+        <dimension size="10"/>
+    </Array>
+    <Float64 name="c d">
+        <Attribute name="long_name" type="String">
+            <value>c d with a WWW escape sequence</value>
+        </Attribute>
+        <Attribute name="sub" type="Container">
+            <Attribute name="about" type="String">
+                <value>Attributes inside attributes</value>
+            </Attribute>
+            <Attribute name="pi" type="Float64">
+                <value>3.1415</value>
+            </Attribute>
+        </Attribute>
+    </Float64>
+    <Grid name="huh">
+        <Attribute name="long_name" type="String">
+            <value>The Grid huh</value>
+        </Attribute>
+        <Array name="Image#data">
+            <Byte/>
+            <dimension size="512"/>
+        </Array>
+        <Map name="colors">
+            <Attribute name="long_name" type="String">
+                <value>The color map vector</value>
+            </Attribute>
+            <String/>
+            <dimension size="512"/>
+        </Map>
+    </Grid>
+    <dataBLOB href=""/>
+</Dataset>

--- a/unit-tests/dds-testsuite/test.19c.dap2.xml
+++ b/unit-tests/dds-testsuite/test.19c.dap2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset name="test.19c" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+    <Attribute name="NC_GLOBAL" type="Container">
+        <Attribute name="long_name" type="String">
+            <value>Attribute merge test</value>
+        </Attribute>
+        <Attribute name="primes" type="Int32">
+            <value>2</value>
+            <value>3</value>
+            <value>5</value>
+            <value>7</value>
+            <value>11</value>
+        </Attribute>
+    </Attribute>
+    <Int32 name="a"/>
+    <dataBLOB href=""/>
+</Dataset>

--- a/unit-tests/dds-testsuite/test.19d.dap2.xml
+++ b/unit-tests/dds-testsuite/test.19d.dap2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset name="test.19d" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+    <Array name="b#c">
+        <Attribute name="long_name" type="String">
+            <value>b pound c</value>
+        </Attribute>
+        <Int32/>
+        <dimension size="10"/>
+    </Array>
+    <dataBLOB href=""/>
+</Dataset>

--- a/unit-tests/dds-testsuite/test.19e.dap2.xml
+++ b/unit-tests/dds-testsuite/test.19e.dap2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset name="test.19e" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+    <Float64 name="c d">
+        <Attribute name="long_name" type="String">
+            <value>c d with a WWW escape sequence</value>
+        </Attribute>
+        <Attribute name="sub" type="Container">
+            <Attribute name="about" type="String">
+                <value>Attributes inside attributes</value>
+            </Attribute>
+            <Attribute name="pi" type="Float64">
+                <value>3.1415</value>
+            </Attribute>
+        </Attribute>
+    </Float64>
+    <dataBLOB href=""/>
+</Dataset>

--- a/unit-tests/dds-testsuite/test.19f.dap2.xml
+++ b/unit-tests/dds-testsuite/test.19f.dap2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset name="test.19f" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xml.opendap.org/ns/DAP2" xsi:schemaLocation="http://xml.opendap.org/ns/DAP2 http://xml.opendap.org/dap/dap2.xsd">
+    <Grid name="huh">
+        <Attribute name="long_name" type="String">
+            <value>The Grid huh</value>
+        </Attribute>
+        <Array name="Image#data">
+            <Byte/>
+            <dimension size="512"/>
+        </Array>
+        <Map name="colors">
+            <Attribute name="long_name2" type="String">
+                <value>The color map vector</value>
+            </Attribute>
+            <String/>
+            <dimension size="512"/>
+        </Map>
+    </Grid>
+    <dataBLOB href=""/>
+</Dataset>


### PR DESCRIPTION
This branch contains the DDX fix, but the code can toggle between DAP2 and DAP 3.2 DDX responses. DAP2 DDXs make fewer BES tests fail, FWIW. But we can switch between the two versions, complete with switched baselines.