### PR TITLE
Added a test for either c++11 or c++0x and its use by the Makefiles

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,9 +28,9 @@ ASAN_FLAGS = -fsanitize=address -fno-omit-frame-pointer
 endif
 
 if BUILD_DEVELOPER
-AM_CXXFLAGS += $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
+AM_CXXFLAGS += $(CXX11_FLAG) $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
 else
-AM_CXXFLAGS += -g -O2
+AM_CXXFLAGS += -g -O2 $(CXX11_FLAG)
 endif
 
 AM_LDFLAGS =

--- a/conf/cxx_flags_check.m4
+++ b/conf/cxx_flags_check.m4
@@ -1,0 +1,22 @@
+
+dnl Shamelessly copied from stackoverflow
+dnl https://stackoverflow.com/questions/1354996/need-an-autoconf-macro-that-detects-if-m64-is-a-valid-compiler-option
+dnl jhrg 3/22/19
+dnl
+dnl @synopsis CXX_FLAGS_CHECK [compiler flags] [ACTION-IF-SUPPORTED] [ACTION-IF-NOT-SUPPORTED]                                       
+dnl @summary check whether compiler supports given C++ flags or not                   
+AC_DEFUN([CXX_FLAGS_CHECK],                                                            
+[dnl                                                                                  
+  AC_MSG_CHECKING([if $CXX supports $1])
+  AC_LANG_PUSH([C++])
+  ac_saved_cxxflags="$CXXFLAGS"                                                       
+  CXXFLAGS="-Werror $1"                                                               
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],                                            
+    [AC_MSG_RESULT([yes])]
+    $2,                                                           
+    [AC_MSG_ERROR([no])]
+    $3                                                              
+  )                                                                                   
+  CXXFLAGS="$ac_saved_cxxflags"                                                       
+  AC_LANG_POP([C++])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -2,11 +2,15 @@
 dnl -*- autoconf -*-
 dnl Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.63)
+dnl AC_PREREQ(2.63)
+AC_PREREQ([2.68])
+dnl m4_pattern_forbid([^_?(gl_[A-Z]|AX_|BISON_)])
+dnl m4_pattern_allow([^BISON_USE_NLS$])
+
 dnl Update version here and below at LIB_CURRENT, ..., if needed.
 AC_INIT(libdap, 3.20.3, opendap-tech@opendap.org)
 AC_DEFINE(DAP_PROTOCOL_VERSION, ["4.0"], [Highest DAP version implemented?])
-AC_SUBST(DAP_PROTOCOL_VERSION)
+AC_SUBST([DAP_PROTOCOL_VERSION])
 
 AC_CONFIG_SRCDIR([Connect.cc])
 AC_CONFIG_AUX_DIR(conf)
@@ -103,6 +107,25 @@ AS_IF([test "x$CC" = xgcc],
 
 dnl AC_PROG_YACC
 dnl AC_PROG_LEX
+
+dnl NB: CentOS 6 does not support C++-11 but does support some features:
+dnl https://gcc.gnu.org/gcc-4.4/cxx0x_status.html.
+dnl For now, I'm counting 0x as supporting C++-11 in our code.
+
+CXX11_FLAG=""
+
+CXX_FLAGS_CHECK([--std=c++11], [CXX11_FLAG=--std=c++11], [])
+
+AS_IF([test -z "$CXX11_FLAG"],
+    [CXX_FLAGS_CHECK([--std=c++0x], [CXX11_FLAG=--std=c++0x], [])])
+    
+AS_IF([test -z "$CXX11_FLAG"],
+      [AC_MSG_ERROR([libdap now needs C++-0x support or greater])],
+      [AC_MSG_NOTICE([Using $CXX11_FLAG for C++-11 support])])
+
+AC_SUBST(CXX11_FLAG)
+
+
 AM_PROG_LEX
 AC_PROG_INSTALL
 AC_PROG_LN_S

--- a/d4_ce/Makefile.am
+++ b/d4_ce/Makefile.am
@@ -33,9 +33,9 @@ ASAN_FLAGS = -fsanitize=address -fno-omit-frame-pointer
 endif
 
 if BUILD_DEVELOPER
-AM_CXXFLAGS += $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
+AM_CXXFLAGS += $(CXX11_FLAG) $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
 else
-AM_CXXFLAGS += -g -O2
+AM_CXXFLAGS += -g -O2 $(CXX11_FLAG)
 endif
 
 AM_LDFLAGS =

--- a/d4_function/Makefile.am
+++ b/d4_function/Makefile.am
@@ -30,9 +30,9 @@ ASAN_FLAGS = -fsanitize=address -fno-omit-frame-pointer
 endif
 
 if BUILD_DEVELOPER
-AM_CXXFLAGS += $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
+AM_CXXFLAGS += $(CXX11_FLAG) $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
 else
-AM_CXXFLAGS += -g -O2
+AM_CXXFLAGS += -g -O2 $(CXX11_FLAG)
 endif
 
 AM_LDFLAGS =

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,9 +21,9 @@ ASAN_FLAGS = -fsanitize=address -fno-omit-frame-pointer
 endif
 
 if BUILD_DEVELOPER
-AM_CXXFLAGS += $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
+AM_CXXFLAGS += $(CXX11_FLAG) $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
 else
-AM_CXXFLAGS += -g -O2
+AM_CXXFLAGS += -g -O2 $(CXX11_FLAG)
 endif
 
 check_PROGRAMS = das-test dds-test expr-test 


### PR DESCRIPTION
No code changes. The idea is to see if this makes it through CI/CD.
C++0x is the prequel to C++11. The '0x' version is supported on
CentOS 6 by gcc/++ 4.4.x