### PR TITLE
Modified the build so that --std=c++-1x works on CentOS 6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,15 +116,14 @@ CXX11_FLAG=""
 
 CXX_FLAGS_CHECK([--std=c++11], [CXX11_FLAG=--std=c++11], [])
 
-dnl AS_IF([test -z "$CXX11_FLAG"],
-dnl    [CXX_FLAGS_CHECK([--std=c++0x], [CXX11_FLAG=--std=c++0x], [])])
+AS_IF([test -z "$CXX11_FLAG"],
+      [CXX_FLAGS_CHECK([--std=c++0x], [CXX11_FLAG=--std=c++0x], [])])
 
 AS_IF([test -z "$CXX11_FLAG"],
       [AC_MSG_NOTICE([Not using C++-11])],
       [AC_MSG_NOTICE([Using $CXX11_FLAG for C++-11 support])])
 
 AC_SUBST(CXX11_FLAG)
-
 
 AM_PROG_LEX
 AC_PROG_INSTALL

--- a/d4_ce/Makefile.am
+++ b/d4_ce/Makefile.am
@@ -32,10 +32,11 @@ if USE_ASAN
 ASAN_FLAGS = -fsanitize=address -fno-omit-frame-pointer
 endif
 
+# See note in d4_function about CXX11_FLAG. jhrg 4/5/19
 if BUILD_DEVELOPER
-AM_CXXFLAGS += $(CXX11_FLAG) $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
+AM_CXXFLAGS += $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
 else
-AM_CXXFLAGS += -g -O2 $(CXX11_FLAG)
+AM_CXXFLAGS += -g -O2 
 endif
 
 AM_LDFLAGS =

--- a/d4_function/Makefile.am
+++ b/d4_function/Makefile.am
@@ -29,10 +29,12 @@ if USE_ASAN
 ASAN_FLAGS = -fsanitize=address -fno-omit-frame-pointer
 endif
 
+# Removed  $(CXX11_FLAG) since c++0x, gcc 4.4.x and bison -gneerated code
+# do not work together. jhrg 4//5/19
 if BUILD_DEVELOPER
-AM_CXXFLAGS += $(CXX11_FLAG) $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
+AM_CXXFLAGS += $(CXXFLAGS_DEBUG) $(ASAN_FLAGS)
 else
-AM_CXXFLAGS += -g -O2 $(CXX11_FLAG)
+AM_CXXFLAGS += -g -O2
 endif
 
 AM_LDFLAGS =


### PR DESCRIPTION
The issue was that the bsin code failed to build. The fix is
to not use the --std=... flag for it. Since it's generated code
we're not using any C++ 2011 stuff. If that changes, it _will_
build with 2011++, but not the 0x implementation found on CentOS 6.