### PR TITLE
Hacked chunked_i/ostream.cc using HEADER_IN_NETWORK_BYTE_ORDER

### DIFF
--- a/chunked_istream.cc
+++ b/chunked_istream.cc
@@ -96,7 +96,7 @@ chunked_inbuf::underflow()
 	// To read data from the chunked stream, first read the header
 	uint32_t header;
 	d_is.read((char *) &header, 4);
-#if !BYTE_ORDER_PREFIX
+#if !BYTE_ORDER_PREFIX && HEADER_IN_NETWORK_BYTE_ORDER
 	// When the endian nature of the server is encoded in the chunk header, the header is
 	// sent using network byte order
 	header = ntohl(header);
@@ -218,7 +218,7 @@ chunked_inbuf::xsgetn(char* s, std::streamsize num)
         // Get a chunk header
         uint32_t header;
         d_is.read((char *) &header, 4);
-#if !BYTE_ORDER_PREFIX
+#if !BYTE_ORDER_PREFIX && HEADER_IN_NETWORK_BYTE_ORDER
         header = ntohl(header);
 #endif
 
@@ -343,7 +343,7 @@ chunked_inbuf::read_next_chunk()
 	// To read data from the chunked stream, first read the header
 	uint32_t header;
 	d_is.read((char *) &header, 4);
-#if !BYTE_ORDER_PREFIX
+#if !BYTE_ORDER_PREFIX && HEADER_IN_NETWORK_BYTE_ORDER
     header = ntohl(header);
 #endif
 

--- a/chunked_ostream.cc
+++ b/chunked_ostream.cc
@@ -77,8 +77,10 @@ chunked_outbuf::data_chunk()
 #if !BYTE_ORDER_PREFIX
 	// Add encoding of host's byte order. jhrg 11/24/13
 	if (!d_big_endian) header |= CHUNK_LITTLE_ENDIAN;
+#if HEADER_IN_NETWORK_BYTE_ORDER
 	// network byte order for the header
 	header = htonl(header);
+#endif
 #endif
 
 	d_os.write((const char *)&header, sizeof(int32_t));
@@ -120,8 +122,10 @@ chunked_outbuf::end_chunk()
 #if !BYTE_ORDER_PREFIX
     // Add encoding of host's byte order. jhrg 11/24/13
     if (!d_big_endian) header |= CHUNK_LITTLE_ENDIAN;
+#if HEADER_IN_NETWORK_BYTE_ORDER
     // network byte order for the header
     header = htonl(header);
+#endif
 #endif
 
     // Write out the CHUNK_END header with the byte count.
@@ -167,8 +171,10 @@ chunked_outbuf::err_chunk(const std::string &m)
 #if !BYTE_ORDER_PREFIX
     // Add encoding of host's byte order. jhrg 11/24/13
     if (!d_big_endian) header |= CHUNK_LITTLE_ENDIAN;
+#if HEADER_IN_NETWORK_BYTE_ORDER
     // network byte order for the header
     header = htonl(header);
+#endif
 #endif
 
     // Write out the CHUNK_END header with the byte count.
@@ -274,8 +280,10 @@ chunked_outbuf::xsputn(const char *s, std::streamsize num)
 #if !BYTE_ORDER_PREFIX
     // Add encoding of host's byte order. jhrg 11/24/13
     if (!d_big_endian) header |= CHUNK_LITTLE_ENDIAN;
+#if HEADER_IN_NETWORK_BYTE_ORDER
     // network byte order for the header
     header = htonl(header);
+#endif
 #endif
 	d_os.write((const char *)&header, sizeof(int32_t));	// Data chunk's CHUNK_TYPE is 0x00000000
 


### PR DESCRIPTION
This is an attempt to revert edits made to correct the calls
to htonl() adn ntohl(). Most thought is needed.