### PR TITLE
11/26/19 - HK-459 - (Awaiting Review) suppressed .yy error messages

### DIFF
--- a/Error.yy
+++ b/Error.yy
@@ -52,6 +52,7 @@ using namespace libdap;
 #define ERROR_OBJ(arg) ((Error *)((parser_arg *)(arg))->_object)
 #define STATUS(arg) ((parser_arg *)(arg))->_status
 
+#define YYERROR_VERBOSE 0
 //#define YYPARSE_PARAM arg
 
 extern int error_line_num;	// defined in Error.lex

--- a/ce_expr.yy
+++ b/ce_expr.yy
@@ -91,6 +91,7 @@ using namespace libdap ;
 #define EVALUATOR(arg) (static_cast<ce_parser_arg*>(arg)->get_eval())
 #define DDS(arg) (static_cast<ce_parser_arg*>(arg)->get_dds())
 
+#define YYERROR_VERBOSE 0
 // #define YYPARSE_PARAM arg
 
 int ce_exprlex(void);		/* the scanner; see expr.lex */

--- a/d4_ce/d4_ce_parser.yy
+++ b/d4_ce/d4_ce_parser.yy
@@ -46,6 +46,7 @@
 // %define api.prefix { d4_ce }
 
 %code requires {
+#define YYERROR_VERBOSE 0
 #include "D4ConstraintEvaluator.h"
 #include "escaping.h" // for www2id() used with WORD and STRING
 namespace libdap {

--- a/d4_ce/d4_ce_scanner.ll
+++ b/d4_ce/d4_ce_scanner.ll
@@ -44,6 +44,8 @@ typedef libdap::D4CEParser::token token;
 /* define yyterminate as this instead of NULL */
 #define yyterminate() return(token::END)
 
+#define YYERROR_VERBOSE 0
+
 #define YY_FATAL_ERROR(msg) {\
     throw(libdap::Error(malformed_expr, std::string("Error scanning constraint expression text: ") + std::string(msg))); \
 }

--- a/d4_function/d4_function_parser.yy
+++ b/d4_function/d4_function_parser.yy
@@ -46,6 +46,8 @@
 
 %code requires {
 
+#define YYERROR_VERBOSE 0
+
 #include "D4FunctionEvaluator.h"
 #include "D4RValue.h"
 #include "dods-datatypes.h"

--- a/das.yy
+++ b/das.yy
@@ -41,6 +41,7 @@
 
 #define YYSTYPE char *
 #define ATTR_STRING_QUOTE_FIX
+#define YYERROR_VERBOSE 0
 
 #include "config.h"
 

--- a/dds.yy
+++ b/dds.yy
@@ -83,6 +83,7 @@ using namespace libdap;
 // ERROR is no longer used. These parsers now signal problems by throwing
 // exceptions. 5/22/2002 jhrg
 #define DDS_OBJ(arg) ((DDS *)((parser_arg *)(arg))->_object)
+#define YYERROR_VERBOSE 0
 
 // #define YYPARSE_PARAM arg
 


### PR DESCRIPTION
suppressed error messages thrown from libdap4/*.yy files to the standard
out
passes make, check, and distcheck