### PR TITLE
HK-532, set the parent pointer of vars to NULL when transforming DAP4…

### DIFF
--- a/D4Group.cc
+++ b/D4Group.cc
@@ -710,6 +710,7 @@ D4Group::transform_to_dap2(AttrTable *parent_attr_table)
             for (vector<BaseType*>::iterator vi = new_vars->begin(), ve = new_vars->end(); vi != ve; vi++) {
                 string new_name = (is_root ? "" : FQN()) + (*vi)->name();
                 (*vi)->set_name(new_name);
+                (*vi)->set_parent(NULL);
                 results->push_back((*vi));
 #if 0
                 (*vi) = NULL;


### PR DESCRIPTION
… to DAP2.
----------
I've checked carefully. As far as I understand, this is, so far, the only place we need to change for the trasnform_to_dap2( ) function.
There is no group concept in DAP2. So when DAP4 is transformed to DAP2,  except the root group, all other groups are ignored. So this one-line change should be OK for the time being.

I've tested at CentOS 7. Current BES and libdap4 tests get passed. FilenetCDF can work with DMRPP files after this change.