### PR TITLE
This change to configure.ac fixes the build for cppunit 1.14.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -389,12 +389,37 @@ AS_IF([test x$enable_asan = xyes -a x$has_asan = xyes],
 AC_ARG_ENABLE([developer],
     [AS_HELP_STRING([--enable-developer], [Build for debug (-g3 -O0); include assert() calls (default: no)])])
 
+dnl This is the default. If the caller uses --enable-developer, that option
+dnl will override these values
+cxx_debug_flags="-g -O2"
+
 AS_IF([test x$enable_developer = xyes],
       [AC_MSG_NOTICE([Building developer version])
-       AM_CONDITIONAL([BUILD_DEVELOPER], [true])],
+       AM_CONDITIONAL([BUILD_DEVELOPER], [true])
+       cxx_debug_flags="-g3 -O0  -Wall -W -Wcast-align"],
       [AC_MSG_NOTICE([Not building developer version])
        AM_CONDITIONAL([BUILD_DEVELOPER], [false])
        AC_DEFINE([NDEBUG], [1], [Define this to suppres assert() calls.])])
+
+dnl NB: CentOS 6 does not support C++-11 but does support some features:
+dnl https://gcc.gnu.org/gcc-4.4/cxx0x_status.html.
+dnl For now, I'm counting 0x as supporting C++-11 in our code.
+
+CXX11_FLAG=""
+
+CXX_FLAGS_CHECK([--std=c++11], [CXX11_FLAG=--std=c++11], [])
+
+AS_IF([test -z "$CXX11_FLAG"],
+      [CXX_FLAGS_CHECK([--std=c++0x], [CXX11_FLAG=--std=c++0x], [])])
+
+AS_IF([test -z "$CXX11_FLAG"],
+      [AC_MSG_ERROR([Not using C++-11 (or C++0x)])],
+      [AC_MSG_NOTICE([Using $CXX11_FLAG for C++-11 support])
+       cxx_debug_flags="$cxx_debug_flags --pedantic $CXX11_FLAG"])
+
+AC_SUBST(CXX11_FLAG)
+
+AS_IF([test -n "$cxx_debug_flags"], [CXXFLAGS="$cxx_debug_flags"])
 
 DODS_GCOV_VALGRIND
 

--- a/d4_ce/d4_ce_scanner.ll
+++ b/d4_ce/d4_ce_scanner.ll
@@ -33,6 +33,8 @@
 
 #include "D4CEScanner.h"
 
+#define YY_NO_UNISTD_H
+
 /* typedef to make the returns for the tokens shorter */
 typedef libdap::D4CEParser::token token;
 

--- a/d4_function/d4_function_scanner.ll
+++ b/d4_function/d4_function_scanner.ll
@@ -34,6 +34,8 @@
 
 #include "D4FunctionScanner.h"
 
+#define YY_NO_UNISTD_H
+
 /* typedef to make the returns for the tokens shorter */
 
 /* NB: It would be best to use the same scanner (and maybe parser) for


### PR DESCRIPTION
The fix instructs the compiler to use --std=c++-11 or c++-0x which
enables cpp 1.14.0's use of std::bind.