### PR TITLE
Added file/line info to the libdap::Error class

### DIFF
--- a/Error.cc
+++ b/Error.cc
@@ -83,8 +83,8 @@ Error::Error() : exception(), _error_code(undefined_error), _error_message("")
 
     @param ec The error code
     @param msg The error message string. */
-Error::Error(ErrorCode ec, string msg)
-        : exception(), _error_code(ec), _error_message(msg)
+Error::Error(ErrorCode ec, string msg, string file /* default: ""*/, int line /* default 0*/)
+        : exception(), _error_code(ec), _error_message(msg), d_file(file), d_line(line)
 {}
 
 /** Create an instance with a specific message. The error code is set to \c
@@ -92,8 +92,8 @@ Error::Error(ErrorCode ec, string msg)
 
     @param msg The error message.
     @see ErrorCode */
-Error::Error(string msg)
-        : exception(), _error_code(unknown_error), _error_message(msg)
+Error::Error(string msg, string file /* default: ""*/, int line /* default 0*/)
+        : exception(), _error_code(unknown_error), _error_message(msg), d_file(file), d_line(line)
 {}
 
 Error::Error(const Error &copy_from)

--- a/Error.h
+++ b/Error.h
@@ -95,9 +95,12 @@ protected:
     ErrorCode _error_code;
     std::string _error_message;
 
+    std::string d_file;
+    int d_line;
+
 public:
-    Error(ErrorCode ec, std::string msg);
-    Error(std::string msg);
+    Error(ErrorCode ec, std::string msg, std::string file = "", int line = 0);
+    Error(std::string msg, std::string file = "", int line = 0);
     Error();
 
     Error(const Error &copy_from);
@@ -114,6 +117,11 @@ public:
     std::string get_error_message() const;
     void set_error_code(ErrorCode ec = undefined_error);
     void set_error_message(std::string msg = "");
+
+    std::string get_file() const { return d_file; }
+    void set_file(std::string f) { d_file = f; }
+    int get_line() const { return d_line; }
+    void set_line(int l) { d_line = l; }
 
     virtual const char* what() const throw() {
         return get_error_message().c_str();

--- a/InternalErr.cc
+++ b/InternalErr.cc
@@ -62,7 +62,7 @@ InternalErr::InternalErr(const string &msg) : Error()
 
 //InternalErr::InternalErr(string msg, string file, int line)
 //    : Error(unknown_error, msg)
-InternalErr::InternalErr(const string &file, const int &line, const string &msg) : Error()
+InternalErr::InternalErr(const string &file, const int &line, const string &msg) : Error(msg, file, line)
 {
     _error_code = internal_error;
     _error_message = "";


### PR DESCRIPTION
This will make it possible to throw libdap::Error objects (not just libdap::InternalErr objects) with file and line info _and_ it will make it possible to extract the file/line info in InternalErr objects. This will improve BES error messages written to the log files.