### PR TITLE
Fixed bug in string handling in Vector

### DIFF
--- a/Vector.cc
+++ b/Vector.cc
@@ -1709,7 +1709,7 @@ bool Vector::set_value(string *val, int sz)
         d_str.resize(sz);
         d_capacity = sz;
         for (register int t = 0; t < sz; t++) {
-            d_str[t] = val[t];
+            d_str[t] = (*val)[t];
         }
         set_length(sz);
         set_read_p(true);


### PR DESCRIPTION
This PR repairs an incorrect pointer dereference in `bool Vector::set_value(string *val, int sz)` The problem code incorrectly accesses the passed string `val` without first dereferencing the point:	

            d_str[t] = val[t];		

This is repaired with a pair of parenthesis and a handy astrerix:

            d_str[t] = (*val)[t];		
