### PR TITLE
Report now built using gcovr, and a small syntax fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
     # Run these commands in bw-output?
     - make check -j7
     - make coverage
-    - find . -wholename \*/.libs/*.gcov -a ! -name \*\#\* -a ! -name \*.hh.gcov > gcov-files.txt
+    - find . -wholename \*/.libs/\*.gcov -a ! -name \*\#\* -a ! -name \*.hh.gcov > gcov-files.txt
     - mkdir -p gcov-reports
     # gcov-reports must be configured in sonar-project.properties. jhrg 11/24/20
     - mv $(cat gcov-files.txt) gcov-reports/

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,10 +34,6 @@ AM_CXXFLAGS += -g -O2 $(CXX11_FLAG)
 endif
 
 AM_LDFLAGS =
-
-# Don't collect coverage for the tests themselves. tests unit-tests
-# jhrg 11/18/20
-coverage_subdirs = d4_ce d4_function
 include $(top_srcdir)/coverage.mk
 
 SUBDIRS = gl d4_ce d4_function . unit-tests tests


### PR DESCRIPTION
The gcovr report might show different detatils than the reports
from sonarscan.