### PR TITLE
Add support for includes prefixed with 'libdap'

### DIFF
--- a/dap-config.in
+++ b/dap-config.in
@@ -55,6 +55,9 @@ while test $# -gt 0; do
 	echo "@CXX@"
 	;;
 
+    # Added -I${includedir} so that code can use #include <libdap/Array.h>, ...
+    # which avoids issues with IDE warnings and will help later when there are
+    # two libdap libraries. jhrg 6/17/21
     --cflags)
 	echo "-I${includedir} -I${includedir}/libdap @XML2_CFLAGS@ @CURL_CFLAGS@"
 	;;

--- a/dap-config.in
+++ b/dap-config.in
@@ -56,7 +56,7 @@ while test $# -gt 0; do
 	;;
 
     --cflags)
-	echo "-I${includedir}/libdap @XML2_CFLAGS@ @CURL_CFLAGS@"
+	echo "-I${includedir} -I${includedir}/libdap @XML2_CFLAGS@ @CURL_CFLAGS@"
 	;;
 
     --libs)


### PR DESCRIPTION
This fix enables code like #include <libdap/Array.h> which
will fix the issue where Array.h clashes with C++-11's 'array.h'
that differes in case only (and triggers warnings in IDEs
making using them tedious. It will also pave the way for code
that uses two different library's headers.