### PR TITLE
Dump auto ptr

### DIFF
--- a/D4Group.cc
+++ b/D4Group.cc
@@ -198,11 +198,6 @@ name_eq(D4Group *g, const string name)
 	return g->name() == name;
 }
 
-static inline std::string &ltrim(std::string &s) {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int c) {return !std::isspace(c);}));
-    return s;
-}
-
 #endif
 
 D4Group *

--- a/D4Group.cc
+++ b/D4Group.cc
@@ -188,6 +188,8 @@ D4Group::FQN() const
 	return (name() == "/") ? "/" : static_cast<D4Group*>(get_parent())->FQN() + name() + "/";
 }
 
+#if 0
+
 // Note that in order for this to work the second argument must not be a reference.
 // jhrg 8/20/13
 static bool
@@ -196,10 +198,18 @@ name_eq(D4Group *g, const string name)
 	return g->name() == name;
 }
 
+static inline std::string &ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int c) {return !std::isspace(c);}));
+    return s;
+}
+
+#endif
+
 D4Group *
 D4Group::find_child_grp(const string &grp_name)
 {
-	groupsIter g = find_if(grp_begin(), grp_end(), bind2nd(ptr_fun(name_eq), grp_name));
+	// groupsIter g = find_if(grp_begin(), grp_end(), bind2nd(ptr_fun(name_eq), grp_name));
+    groupsIter g = find_if(grp_begin(), grp_end(), [grp_name](D4Group *g) { return g->name() == grp_name; });
 	return (g == grp_end()) ? 0: *g;
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -584,6 +584,7 @@ AC_CONFIG_FILES([Makefile
                  unit-tests/Makefile
                  unit-tests/cache-testsuite/Makefile])
 
-AC_CONFIG_FILES([dap-config], [chmod +x dap-config]) 
+AC_CONFIG_FILES([dap-config], [chmod +x dap-config])
+# AC_CONFIG_FILES([unit-tests/cache-testsuite/cleanup.sh], [chmod +x unit-tests/cache-testsuite/cleanup.sh])
 	
 AC_OUTPUT

--- a/unit-tests/D4FilterClauseTest.cc
+++ b/unit-tests/D4FilterClauseTest.cc
@@ -117,25 +117,25 @@ public:
         D4RValue *arg1 = new D4RValue(byte);    // holds 17
         D4RValue *arg2 = new D4RValue((long long) 21);
 
-        auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+        unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
         CPPUNIT_ASSERT(less->value(dmr));
 
         D4RValue *arg2_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg2_2 = new D4RValue((long long) 21);
 
-        auto_ptr<D4FilterClause> greater(new D4FilterClause(D4FilterClause::greater, arg2_1, arg2_2));
+        unique_ptr<D4FilterClause> greater(new D4FilterClause(D4FilterClause::greater, arg2_1, arg2_2));
         CPPUNIT_ASSERT(!greater->value(dmr));
 
         D4RValue *arg3_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg3_2 = new D4RValue((long long) 21);
 
-        auto_ptr<D4FilterClause> equal(new D4FilterClause(D4FilterClause::equal, arg3_1, arg3_2));
+        unique_ptr<D4FilterClause> equal(new D4FilterClause(D4FilterClause::equal, arg3_1, arg3_2));
         CPPUNIT_ASSERT(!equal->value(dmr));
 
         D4RValue *arg4_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg4_2 = new D4RValue((long long) 21);
 
-        auto_ptr<D4FilterClause> not_equal(new D4FilterClause(D4FilterClause::not_equal, arg4_1, arg4_2));
+        unique_ptr<D4FilterClause> not_equal(new D4FilterClause(D4FilterClause::not_equal, arg4_1, arg4_2));
         CPPUNIT_ASSERT(not_equal->value(dmr));
     }
 
@@ -145,25 +145,25 @@ public:
         D4RValue *arg1 = new D4RValue(byte);    // holds 17
         D4RValue *arg2 = new D4RValue((long long) 21);
 
-        auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+        unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
         CPPUNIT_ASSERT(less->value());
 
         D4RValue *arg2_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg2_2 = new D4RValue((long long) 21);
 
-        auto_ptr<D4FilterClause> greater(new D4FilterClause(D4FilterClause::greater, arg2_1, arg2_2));
+        unique_ptr<D4FilterClause> greater(new D4FilterClause(D4FilterClause::greater, arg2_1, arg2_2));
         CPPUNIT_ASSERT(!greater->value());
 
         D4RValue *arg3_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg3_2 = new D4RValue((long long) 21);
 
-        auto_ptr<D4FilterClause> equal(new D4FilterClause(D4FilterClause::equal, arg3_1, arg3_2));
+        unique_ptr<D4FilterClause> equal(new D4FilterClause(D4FilterClause::equal, arg3_1, arg3_2));
         CPPUNIT_ASSERT(!equal->value());
 
         D4RValue *arg4_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg4_2 = new D4RValue((long long) 21);
 
-        auto_ptr<D4FilterClause> not_equal(new D4FilterClause(D4FilterClause::not_equal, arg4_1, arg4_2));
+        unique_ptr<D4FilterClause> not_equal(new D4FilterClause(D4FilterClause::not_equal, arg4_1, arg4_2));
         CPPUNIT_ASSERT(not_equal->value());
     }
 
@@ -172,25 +172,25 @@ public:
         D4RValue *arg1 = new D4RValue(byte);    // holds 17
         D4RValue *arg2 = new D4RValue((double) 21.0);
 
-        auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+        unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
         CPPUNIT_ASSERT(less->value(dmr));
 
         D4RValue *arg2_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg2_2 = new D4RValue((double) 21);
 
-        auto_ptr<D4FilterClause> greater(new D4FilterClause(D4FilterClause::greater, arg2_1, arg2_2));
+        unique_ptr<D4FilterClause> greater(new D4FilterClause(D4FilterClause::greater, arg2_1, arg2_2));
         CPPUNIT_ASSERT(!greater->value(dmr));
 
         D4RValue *arg3_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg3_2 = new D4RValue((double) 21);
 
-        auto_ptr<D4FilterClause> equal(new D4FilterClause(D4FilterClause::equal, arg3_1, arg3_2));
+        unique_ptr<D4FilterClause> equal(new D4FilterClause(D4FilterClause::equal, arg3_1, arg3_2));
         CPPUNIT_ASSERT(!equal->value(dmr));
 
         D4RValue *arg4_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg4_2 = new D4RValue((double) 21);
 
-        auto_ptr<D4FilterClause> not_equal(new D4FilterClause(D4FilterClause::not_equal, arg4_1, arg4_2));
+        unique_ptr<D4FilterClause> not_equal(new D4FilterClause(D4FilterClause::not_equal, arg4_1, arg4_2));
         CPPUNIT_ASSERT(not_equal->value(dmr));
     }
 
@@ -202,7 +202,7 @@ public:
         D4RValue *arg1 = new D4RValue(byte);    // holds 17
         D4RValue *arg2 = new D4RValue((unsigned long long) (21));
 
-        auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+        unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
         CPPUNIT_ASSERT(less->value());
 
     }
@@ -212,7 +212,7 @@ public:
         D4RValue *arg1 = new D4RValue(byte);    // holds 17
         D4RValue *arg2 = new D4RValue((float) 21.0);
 
-        auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+        unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
         CPPUNIT_ASSERT(less->value());
 
     }
@@ -224,25 +224,25 @@ public:
         D4RValue *arg1 = new D4RValue(str);
         D4RValue *arg2 = new D4RValue(string("Tesla"));
 
-        auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+        unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
         CPPUNIT_ASSERT(less->value());
 
         D4RValue *arg2_1 = new D4RValue(str);
         D4RValue *arg2_2 = new D4RValue("Tesla");
 
-        auto_ptr<D4FilterClause> greater(new D4FilterClause(D4FilterClause::greater, arg2_1, arg2_2));
+        unique_ptr<D4FilterClause> greater(new D4FilterClause(D4FilterClause::greater, arg2_1, arg2_2));
         CPPUNIT_ASSERT(!greater->value());
 
         D4RValue *arg3_1 = new D4RValue(str);
         D4RValue *arg3_2 = new D4RValue("Tesla");
 
-        auto_ptr<D4FilterClause> equal(new D4FilterClause(D4FilterClause::equal, arg3_1, arg3_2));
+        unique_ptr<D4FilterClause> equal(new D4FilterClause(D4FilterClause::equal, arg3_1, arg3_2));
         CPPUNIT_ASSERT(!equal->value(dmr));
 
         D4RValue *arg4_1 = new D4RValue(str);
         D4RValue *arg4_2 = new D4RValue("Tesla");
 
-        auto_ptr<D4FilterClause> not_equal(new D4FilterClause(D4FilterClause::not_equal, arg4_1, arg4_2));
+        unique_ptr<D4FilterClause> not_equal(new D4FilterClause(D4FilterClause::not_equal, arg4_1, arg4_2));
         CPPUNIT_ASSERT(not_equal->value(dmr));
     }
 
@@ -251,7 +251,7 @@ public:
         D4RValue *arg1 = new D4RValue(str);
         D4RValue *arg2 = new D4RValue(string("E.*n"));
 
-        auto_ptr<D4FilterClause> match(new D4FilterClause(D4FilterClause::match, arg1, arg2));
+        unique_ptr<D4FilterClause> match(new D4FilterClause(D4FilterClause::match, arg1, arg2));
         CPPUNIT_ASSERT(match->value());
     }
 
@@ -261,7 +261,7 @@ public:
         D4RValue *arg2 = new D4RValue((long long) 21);
 
         try {
-            auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+            unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
             // The Filter Clause instance is built OK, but the value() method
             // will balk at this comparison. jhrg 4/21/16
             DBG(cerr << "built filter clause instance" << endl);
@@ -281,7 +281,7 @@ public:
         D4RValue *arg2 = new D4RValue("Tesla");
 
         try {
-            auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+            unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
 
             CPPUNIT_ASSERT(less->value());
             CPPUNIT_FAIL("Expected error");
@@ -294,13 +294,13 @@ public:
 
     void Structure_and_string_error_test()
     {
-        auto_ptr<Structure> s(new Structure("s"));
+        unique_ptr<Structure> s(new Structure("s"));
         s->add_var(byte); // copy the object
         D4RValue *arg1 = new D4RValue(s.get()); // BaseType*s are not free'd by D4RValue
         D4RValue *arg2 = new D4RValue("Tesla");
 
         try {
-            auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+            unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
 
             CPPUNIT_ASSERT(less->value());
             CPPUNIT_FAIL("Expected error");
@@ -314,13 +314,13 @@ public:
     // There's no way this will get past the parser, but ...
     void Byte_and_Structure_error_test()
     {
-        auto_ptr<Structure> s(new Structure("s"));
+        unique_ptr<Structure> s(new Structure("s"));
         s->add_var(str); // copy the object
         D4RValue *arg1 = new D4RValue(byte);
         D4RValue *arg2 = new D4RValue(s.get());
 
         try {
-            auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+            unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
 
             CPPUNIT_ASSERT(less->value());
             CPPUNIT_FAIL("Expected error");
@@ -334,13 +334,13 @@ public:
     // There's no way this will get past the parser, but ...
     void Str_and_Structure_error_test()
     {
-        auto_ptr<Structure> s(new Structure("s"));
+        unique_ptr<Structure> s(new Structure("s"));
         s->add_var(str); // copy the object
         D4RValue *arg1 = new D4RValue(str);
         D4RValue *arg2 = new D4RValue(s.get());
 
         try {
-            auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
+            unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg1, arg2));
 
             CPPUNIT_ASSERT(less->value());
             CPPUNIT_FAIL("Expected error");
@@ -357,25 +357,25 @@ public:
         D4RValue *arg2_1 = new D4RValue(f32);
         D4RValue *arg2_2 = new D4RValue(17.0);
 
-        auto_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg2_1, arg2_2));
+        unique_ptr<D4FilterClause> less(new D4FilterClause(D4FilterClause::less, arg2_1, arg2_2));
         CPPUNIT_ASSERT(less->value());
 
         D4RValue *arg3_1 = new D4RValue(url);
         D4RValue *arg3_2 = new D4RValue("https://github.com/opendap");
 
-        auto_ptr<D4FilterClause> equal(new D4FilterClause(D4FilterClause::equal, arg3_1, arg3_2));
+        unique_ptr<D4FilterClause> equal(new D4FilterClause(D4FilterClause::equal, arg3_1, arg3_2));
         CPPUNIT_ASSERT(equal->value(dmr));
 
         D4RValue *arg4_1 = new D4RValue(url);
         D4RValue *arg4_2 = new D4RValue("https://.*dap$");
 
-        auto_ptr<D4FilterClause> not_equal(new D4FilterClause(D4FilterClause::not_equal, arg4_1, arg4_2));
+        unique_ptr<D4FilterClause> not_equal(new D4FilterClause(D4FilterClause::not_equal, arg4_1, arg4_2));
         CPPUNIT_ASSERT(not_equal->value(dmr));
 
         D4RValue *arg5_1 = new D4RValue(url);
         D4RValue *arg5_2 = new D4RValue("https://.*dap$");
 
-        auto_ptr<D4FilterClause> match(new D4FilterClause(D4FilterClause::match, arg5_1, arg5_2));
+        unique_ptr<D4FilterClause> match(new D4FilterClause(D4FilterClause::match, arg5_1, arg5_2));
         CPPUNIT_ASSERT(match->value(dmr));
     }
 
@@ -384,7 +384,7 @@ public:
         D4RValue *arg2_1 = new D4RValue(f32);
         D4RValue *arg2_2 = new D4RValue(3.1415);
 
-        auto_ptr<D4FilterClause> clause(new D4FilterClause(D4FilterClause::equal, arg2_1, arg2_2));
+        unique_ptr<D4FilterClause> clause(new D4FilterClause(D4FilterClause::equal, arg2_1, arg2_2));
         CPPUNIT_ASSERT(clause->value());
     }
 
@@ -393,7 +393,7 @@ public:
         D4RValue *arg2_1 = new D4RValue(f32);
         D4RValue *arg2_2 = new D4RValue(3.1415);
 
-        auto_ptr<D4FilterClause> clause(new D4FilterClause(D4FilterClause::greater_equal, arg2_1, arg2_2));
+        unique_ptr<D4FilterClause> clause(new D4FilterClause(D4FilterClause::greater_equal, arg2_1, arg2_2));
         CPPUNIT_ASSERT(clause->value());
     }
 
@@ -402,25 +402,25 @@ public:
         D4RValue *arg2_1 = new D4RValue(f32);
         D4RValue *arg2_2 = new D4RValue(3.1415);
 
-        auto_ptr<D4FilterClause> clause(new D4FilterClause(D4FilterClause::less_equal, arg2_1, arg2_2));
+        unique_ptr<D4FilterClause> clause(new D4FilterClause(D4FilterClause::less_equal, arg2_1, arg2_2));
         CPPUNIT_ASSERT(clause->value());
     }
 
     void int_test()
     {
-        auto_ptr<Int8> i8(new Int8(""));
+        unique_ptr<Int8> i8(new Int8(""));
         i8->set_value(17);
         D4RValue *arg2_1 = new D4RValue(i8.get());
         D4RValue *arg2_2 = new D4RValue((long long) 17);
 
-        auto_ptr<D4FilterClause> clause(new D4FilterClause(D4FilterClause::equal, arg2_1, arg2_2));
+        unique_ptr<D4FilterClause> clause(new D4FilterClause(D4FilterClause::equal, arg2_1, arg2_2));
         CPPUNIT_ASSERT(clause->value());
     }
 
     void true_clauses_test()
     {
         // Testing this as a pointer since that's how it will be stored in D4Sequence
-        auto_ptr<D4FilterClauseList> clauses(new D4FilterClauseList());
+        unique_ptr<D4FilterClauseList> clauses(new D4FilterClauseList());
 
         D4RValue *arg1_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg1_2 = new D4RValue((double) 21.0);
@@ -446,7 +446,7 @@ public:
     // This should return true
     void no_clauses_test()
     {
-        auto_ptr<D4FilterClauseList> clauses(new D4FilterClauseList());
+        unique_ptr<D4FilterClauseList> clauses(new D4FilterClauseList());
 
         CPPUNIT_ASSERT(clauses->size() == 0);
         CPPUNIT_ASSERT(clauses->value(dmr));
@@ -455,7 +455,7 @@ public:
 
     void false_clauses_test()
     {
-        auto_ptr<D4FilterClauseList> clauses(new D4FilterClauseList());
+        unique_ptr<D4FilterClauseList> clauses(new D4FilterClauseList());
 
         D4RValue *arg1_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg1_2 = new D4RValue((double) 21.0);
@@ -481,7 +481,7 @@ public:
 
     void evaluation_order_test()
     {
-        auto_ptr<D4FilterClauseList> clauses(new D4FilterClauseList());
+        unique_ptr<D4FilterClauseList> clauses(new D4FilterClauseList());
 
         D4RValue *arg1_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg1_2 = new D4RValue((double) 21.0);
@@ -515,7 +515,7 @@ public:
 
     void evaluation_order_test_2()
     {
-        auto_ptr<D4FilterClauseList> clauses(new D4FilterClauseList());
+        unique_ptr<D4FilterClauseList> clauses(new D4FilterClauseList());
 
         D4RValue *arg1_1 = new D4RValue(byte);    // holds 17
         D4RValue *arg1_2 = new D4RValue((double) 21.0);

--- a/unit-tests/D4GroupTest.cc
+++ b/unit-tests/D4GroupTest.cc
@@ -304,6 +304,35 @@ public:
         CPPUNIT_ASSERT(btp->get_parent()->name() == "child" && btp->get_parent()->get_parent()->name() == "/");
     }
 
+    void test_find_var_2()
+    {
+        D4Group *child = new D4Group("child");
+        D4Group *g_child_1 = new D4Group("g_child_1");
+        D4Group *g_child_2 = new D4Group("g_child_2");
+
+        load_group_with_scalars(g_child_1);
+        load_group_with_stuff(g_child_2);
+
+        child->add_group_nocopy(g_child_1);
+        child->add_group_nocopy(g_child_2);
+
+        root->add_group_nocopy(child);
+
+        g_child_1->add_var_nocopy(new Byte("byte_var_gc_1"));
+        g_child_2->add_var_nocopy(new Byte("byte_var_gc_2"));
+
+        auto bv_gc_1 = root->find_var("/child/g_child_1/byte_var_gc_1");
+        CPPUNIT_ASSERT(bv_gc_1);
+
+        auto bv_gc_2 = root->find_var("/child/g_child_2/byte_var_gc_2");
+        CPPUNIT_ASSERT(bv_gc_2);
+
+        auto its_not_there = root->find_var("/child/g_child_2/byte_var_gc_1");
+        CPPUNIT_ASSERT(its_not_there == nullptr);
+        // grp1 = new D4Group("Joey");
+        // grp1->dims()->add_dim_nocopy(new D4Dimension("lat", 1024));
+        // grp1->add_var_nocopy(new Byte("byte_var"));
+    }
     void test_print_everything()
     {
         load_group_with_scalars(root);
@@ -417,13 +446,7 @@ public:
         CPPUNIT_ASSERT(btp && btp->FQN() == "/child/p.c.b");
     }
 
-    void test_find_var_2()
-    {
-        // grp1 = new D4Group("Joey");
-        // grp1->dims()->add_dim_nocopy(new D4Dimension("lat", 1024));        
-        // grp1->add_var_nocopy(new Byte("byte_var"));
-        
-    }        
+
 
     CPPUNIT_TEST_SUITE (D4GroupTest);
 
@@ -449,6 +472,7 @@ public:
     CPPUNIT_TEST (test_print_everything);
 
     CPPUNIT_TEST (test_find_var);
+    CPPUNIT_TEST (test_find_var_2);
 
     CPPUNIT_TEST (test_print_copy_ctor);
     CPPUNIT_TEST (test_print_assignment);
@@ -457,7 +481,6 @@ public:
     CPPUNIT_TEST (test_fqn_2);
     CPPUNIT_TEST (test_fqn_3);
     CPPUNIT_TEST (test_fqn_4);
-    CPPUNIT_TEST (test_find_var_2);
 
     CPPUNIT_TEST_SUITE_END();
 };

--- a/unit-tests/D4SequenceTest.cc
+++ b/unit-tests/D4SequenceTest.cc
@@ -127,7 +127,7 @@ public:
 
     void copy_ctor_test()
     {
-        auto_ptr<TestD4Sequence> ts(new TestD4Sequence(*s));
+        unique_ptr<TestD4Sequence> ts(new TestD4Sequence(*s));
         ts->intern_data();
 
         CPPUNIT_ASSERT(ts->length() == 7);

--- a/unit-tests/DDSTest.cc
+++ b/unit-tests/DDSTest.cc
@@ -554,7 +554,7 @@ public:
             das.parse((string) TEST_SRC_DIR + "/dds-testsuite/fnoc1.nc.das");
             dds.transfer_attributes(&das);
 
-            auto_ptr<DAS> new_das(dds.get_das());
+            unique_ptr<DAS> new_das(dds.get_das());
 
             string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/fnoc1.nc.das");
             ostringstream oss;
@@ -586,8 +586,8 @@ public:
 
             parser.intern(ifs, &dmr);
 
-            auto_ptr<DDS> dds(dmr.getDDS());
-            auto_ptr<DAS> das(dds->get_das());
+            unique_ptr<DDS> dds(dmr.getDDS());
+            unique_ptr<DAS> das(dds->get_das());
 
             string baseline = read_test_baseline(string(TEST_SRC_DIR) + "/dmr-testsuite/coads_climatology.nc.full.dmr.das");
             ostringstream oss;
@@ -613,7 +613,7 @@ public:
             das.parse((string) TEST_SRC_DIR + "/dds-testsuite/fnoc1.nc.das.no_var");
             dds.transfer_attributes(&das);
 
-            auto_ptr<DAS> new_das(dds.get_das());
+            unique_ptr<DAS> new_das(dds.get_das());
 
             string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/fnoc1.nc.das.no_var");
             ostringstream oss;
@@ -639,7 +639,7 @@ public:
             das.parse((string) TEST_SRC_DIR + "/dds-testsuite/fnoc1.nc.das.no_global");
             dds.transfer_attributes(&das);
 
-            auto_ptr<DAS> new_das(dds.get_das());
+            unique_ptr<DAS> new_das(dds.get_das());
 
             string baseline = read_test_baseline((string) TEST_SRC_DIR + "/dds-testsuite/fnoc1.nc.das.no_global");
             ostringstream oss;
@@ -667,8 +667,8 @@ public:
 
             parser.intern(ifs, &dmr);
 
-            auto_ptr<DDS> dds(dmr.getDDS());
-            auto_ptr<DAS> das(dds->get_das());
+            unique_ptr<DDS> dds(dmr.getDDS());
+            unique_ptr<DAS> das(dds->get_das());
 
             string baseline = read_test_baseline(string(TEST_SRC_DIR) +  "/dmr-to-dap2-testsuite/1A.GPM.GMI.COUNT2014v3.20160105.h5.dmrpp.dmr.baseline");
             ostringstream oss;
@@ -695,8 +695,8 @@ public:
 
             parser.intern(ifs, &dmr);
 
-            auto_ptr<DDS> dds(dmr.getDDS());
-            auto_ptr<DAS> das(dds->get_das());
+            unique_ptr<DDS> dds(dmr.getDDS());
+            unique_ptr<DAS> das(dds->get_das());
 
             string baseline = read_test_baseline(string(TEST_SRC_DIR) +  "/dmr-to-dap2-testsuite/hacked.dmrpp.dmr.baseline");
             ostringstream oss;

--- a/unit-tests/DmrToDap2Test.cc
+++ b/unit-tests/DmrToDap2Test.cc
@@ -147,7 +147,7 @@ public:
         DBG(cerr << __func__ << "() - BEGIN (test_base: " << test_base_name << ")" << endl);
 
         try {
-            auto_ptr<DMR> dmr(build_dmr(dmr_file));
+            unique_ptr<DMR> dmr(build_dmr(dmr_file));
             CPPUNIT_ASSERT(dmr.get() != 0);
             XMLWriter xml;
             dmr->print_dap4(xml);
@@ -159,7 +159,7 @@ public:
 
             CPPUNIT_ASSERT(result_dmr == baseline_dmr);
 
-            auto_ptr<DDS> dds(dmr->getDDS());
+            unique_ptr<DDS> dds(dmr->getDDS());
             ostringstream result_dds;
             dds->print(result_dds);
             string baseline_dds = read_test_baseline(dds_file);

--- a/unit-tests/HTTPCacheTest.cc
+++ b/unit-tests/HTTPCacheTest.cc
@@ -543,7 +543,7 @@ public:
         try {
             delete hc;
             hc = 0;
-            auto_ptr<HTTPCache> gc(new HTTPCache("cache-testsuite/gc_cache", true));
+            unique_ptr<HTTPCache> gc(new HTTPCache("cache-testsuite/gc_cache", true));
             DBG(cerr << "get_cache_root: " << gc->get_cache_root() << endl);
 
             HTTPResponse *rs = http_conn->fetch_url(localhost_url);
@@ -575,7 +575,7 @@ public:
     void purge_cache_and_release_cached_response_test()
     {
         try {
-            auto_ptr<HTTPCache> pc(new HTTPCache("cache-testsuite/purge_cache", true));
+            unique_ptr<HTTPCache> pc(new HTTPCache("cache-testsuite/purge_cache", true));
             DBG(cerr << "get_cache_root: " << pc->get_cache_root() << endl);
 
             time_t now = time(0);
@@ -686,7 +686,7 @@ public:
     void get_conditional_response_headers_test()
     {
         try {
-            auto_ptr<HTTPCache> c(new HTTPCache("cache-testsuite/header_cache", true));
+            unique_ptr<HTTPCache> c(new HTTPCache("cache-testsuite/header_cache", true));
             DBG(cerr << "get_cache_root: " << c->get_cache_root() << endl);
 
             CPPUNIT_ASSERT(c->get_cache_root() == "cache-testsuite/header_cache/");
@@ -723,7 +723,7 @@ public:
     void update_response_test()
     {
         try {
-            auto_ptr<HTTPCache> c(new HTTPCache("cache-testsuite/singleton_cache", true));
+            unique_ptr<HTTPCache> c(new HTTPCache("cache-testsuite/singleton_cache", true));
             DBG(cerr << "get_cache_root: " << c->get_cache_root() << endl);
 
             if (!c->is_url_in_cache(localhost_url)) {
@@ -786,7 +786,7 @@ public:
     void interrupt_test()
     {
         try {
-            auto_ptr<HTTPCache> c(new HTTPCache("cache-testsuite/singleton_cache", true));
+            unique_ptr<HTTPCache> c(new HTTPCache("cache-testsuite/singleton_cache", true));
             string coads = "http://test.opendap.org/dap/data/nc/coads_climatology.nc";
             if (!c->is_url_in_cache(coads)) {
                 HTTPResponse *rs = http_conn->fetch_url(coads);
@@ -807,7 +807,7 @@ public:
         string jan = "http://test.opendap.org/dap/data/nc/jan.nc.dds";
         string feb = "http://test.opendap.org/dap/data/nc/feb.nc.dds";
         try {
-            auto_ptr<HTTPCache> pc(new HTTPCache("cache-testsuite/purge_cache", true));
+            unique_ptr<HTTPCache> pc(new HTTPCache("cache-testsuite/purge_cache", true));
 #if 0
             // This broke Fedora ppc64le system with XFS system
             CPPUNIT_ASSERT(pc->d_http_cache_table->d_block_size == 4096);
@@ -856,7 +856,7 @@ public:
         // performed. The feb URL should have been deleted.
 
         try {
-            auto_ptr<HTTPCache> pc(new HTTPCache("cache-testsuite/purge_cache", true));
+            unique_ptr<HTTPCache> pc(new HTTPCache("cache-testsuite/purge_cache", true));
             CPPUNIT_ASSERT(!pc->is_url_in_cache(feb));
         }
         catch (Error &e) {

--- a/unit-tests/cache-testsuite/Makefile.am
+++ b/unit-tests/cache-testsuite/Makefile.am
@@ -4,7 +4,10 @@ EXTRA_DIST = cleanup.sh.in dodsrc dot.index dods_cache_init
 
 DISTCLEANFILES = cleanup.sh
 
-cleanup.sh: cleanup.sh.in $(top_srcdir)/config.status
+# Removed. This breaks autmake 1.16. jhrg 11/23/21
+# $(top_srcdir)/config.status
+
+cleanup.sh: cleanup.sh.in 
 	sed -e "s%[@]srcdir[@]%${srcdir}%" $< > $(builddir)/cleanup.sh
 	chmod +x cleanup.sh
 

--- a/unit-tests/cache-testsuite/Makefile.am
+++ b/unit-tests/cache-testsuite/Makefile.am
@@ -4,8 +4,8 @@ EXTRA_DIST = cleanup.sh.in dodsrc dot.index dods_cache_init
 
 DISTCLEANFILES = cleanup.sh
 
-cleanup.sh: cleanup.sh.in ../../config.status
-	sed -e "s%[@]srcdir[@]%${srcdir}%" $< > cleanup.sh
+cleanup.sh: cleanup.sh.in $(top_srcdir)/config.status
+	sed -e "s%[@]srcdir[@]%${srcdir}%" $< > $(builddir)/cleanup.sh
 	chmod +x cleanup.sh
 
 clean-local: cleanup.sh

--- a/unit-tests/cache-testsuite/cleanup.sh.in
+++ b/unit-tests/cache-testsuite/cleanup.sh.in
@@ -13,8 +13,6 @@ rm -rf dods_cache
 cp -r @srcdir@/dods_cache_init dods_cache
 # make sure we can write to the directory and sub directories
 chmod -R +w dods_cache
-# remove the .svn directory from dods_cache
-rm -rf `find dods_cache -name .svn`
 
 # remove generated cache directories
 rm -rf gc_cache


### PR DESCRIPTION
I found and change a number of uses of auto_ptr in the libdap unit tests. I converted them to unique_ptr. Also updated bind2nd/ptr_fun to a lambda (in D4Group). Added a test for the latter.