### PR TITLE
Replaced instances of &vector[0] with vector.data()

### DIFF
--- a/D4Opaque.cc
+++ b/D4Opaque.cc
@@ -71,7 +71,7 @@ D4Opaque::clear_local_data()
 void
 D4Opaque::compute_checksum(Crc32 &checksum)
 {
-	checksum.AddData(&d_buf[0], d_buf.size());
+	checksum.AddData(d_buf.data(), d_buf.size());
 }
 
 void
@@ -80,7 +80,7 @@ D4Opaque::serialize(D4StreamMarshaller &m, DMR &, bool)
     if (!read_p())
         read();          // read() throws Error
 
-    m.put_opaque_dap4( reinterpret_cast<char*>(&d_buf[0]), d_buf.size() ) ;
+    m.put_opaque_dap4( reinterpret_cast<char*>(d_buf.data()), d_buf.size() ) ;
 
 #ifdef CLEAR_LOCAL_DATA
     clear_local_data();

--- a/D4StreamMarshaller.cc
+++ b/D4StreamMarshaller.cc
@@ -142,7 +142,7 @@ void D4StreamMarshaller::m_serialize_reals(char *val, unsigned int num, int widt
 
     char *buf = new char[size];
     XDR xdr;
-    xdrmem_create(&xdr, &buf[0], size, XDR_ENCODE);
+    xdrmem_create(&xdr, buf.data(), size, XDR_ENCODE);
     try {
         if(!xdr_array(&xdr, &val, (unsigned int *)&num, size, width, XDRUtils::xdr_coder(type)))
             throw InternalErr(__FILE__, __LINE__, "Error serializing a Float64 array");
@@ -154,14 +154,14 @@ void D4StreamMarshaller::m_serialize_reals(char *val, unsigned int num, int widt
         static bool twiddle_bytes = !is_host_big_endian();
         if (twiddle_bytes) {
             if (width == 4) {
-                dods_float32 *lbuf = reinterpret_cast<dods_float32*>(&buf[0]);
+                dods_float32 *lbuf = reinterpret_cast<dods_float32*>(buf.data());
                 while (num--) {
                     dods_int32 *i = reinterpret_cast<dods_int32*>(lbuf++);
                     *i = bswap_32(*i);
                 }
             }
             else { // width == 8
-                dods_float64 *lbuf = reinterpret_cast<dods_float64*>(&buf[0]);
+                dods_float64 *lbuf = reinterpret_cast<dods_float64*>(buf.data());
                 while (num--) {
                     dods_int64 *i = reinterpret_cast<dods_int64*>(lbuf++);
                     *i = bswap_64(*i);
@@ -177,7 +177,7 @@ void D4StreamMarshaller::m_serialize_reals(char *val, unsigned int num, int widt
         // The child thread will delete buf when it's done
         xdr_destroy(&xdr);
 #else
-        d_out.write(&buf[0], size);
+        d_out.write(buf.data(), size);
         xdr_destroy(&xdr);
         delete [] buf;
 #endif

--- a/D4StreamUnMarshaller.cc
+++ b/D4StreamUnMarshaller.cc
@@ -293,7 +293,7 @@ D4StreamUnMarshaller::get_opaque_dap4( vector<uint8_t> &val )
 	d_in.read(reinterpret_cast<char*>(&len), sizeof(len));
 
     val.resize(len);
-    d_in.read(reinterpret_cast<char*>(&val[0]), len);
+    d_in.read(reinterpret_cast<char*>(val.data()), len);
 }
 
 void
@@ -309,10 +309,10 @@ void D4StreamUnMarshaller::m_deserialize_reals(char *val, int64_t num, int width
     // char *buf = (char*)malloc(size); jhrg 7/23/13
     vector<char> buf(size);
     XDR xdr;
-    xdrmem_create(&xdr, &buf[0], size, XDR_DECODE);
+    xdrmem_create(&xdr, buf.data(), size, XDR_DECODE);
     try {
         xdr_setpos(&d_source, 0);
-        d_in.read(&buf[0], size);
+        d_in.read(buf.data(), size);
 
         if(!xdr_array(&xdr, &val, (unsigned int *)&num, size, width, XDRUtils::xdr_coder(type)))
             throw InternalErr(__FILE__, __LINE__, "Error deserializing a Float64 array");

--- a/DODSFilter.cc
+++ b/DODSFilter.cc
@@ -901,12 +901,12 @@ DODSFilter::dataset_constraint_ddx(DDS & dds, ConstraintEvaluator & eval,
     uuid_t uu;
     uuid_generate(uu);
     char uuid[37];
-    uuid_unparse(uu, &uuid[0]);
+    uuid_unparse(uu, uuid);
     char domain[256];
     if (getdomainname(domain, 255) != 0 || strlen(domain) == 0)
 	strncpy(domain, "opendap.org", 255);
 
-    string cid = string(&uuid[0]) + "@" + string(&domain[0]);
+    string cid = string(uuid) + "@" + string(domain);
 
     // Send constrained DDX with a data blob reference
     dds.print_xml_writer(out, true, cid);

--- a/GNU/GNURegex.cc
+++ b/GNU/GNURegex.cc
@@ -85,9 +85,9 @@ Regex::init(const char *t)
         vector<char> msg(msg_len+1);
         //char *msg = new char[msg_len+1];
         DBG( cerr << "Regex::init() - Calling regerror() again..." << endl);
-        regerror(result, static_cast<regex_t*>(d_preg), &msg[0], msg_len);
+        regerror(result, static_cast<regex_t*>(d_preg), msg.data(), msg_len);
         DBG( cerr << "Regex::init() - Throwing libdap::Error" << endl);
-        throw Error(string("Regex error: ") + string(&msg[0]));
+        throw Error(string("Regex error: ") + string(msg.data()));
         //delete[] msg;
         //throw e;
     }

--- a/GNU/GetOpt.cc
+++ b/GNU/GetOpt.cc
@@ -79,7 +79,7 @@ GetOpt::exchange (char **argv)
   
   /* Interchange the two blocks of data in argv.  */
 
-  memcpy (&temp[0], &argv[first_nonopt], nonopts_size);
+  memcpy (temp.data(), &argv[first_nonopt], nonopts_size);
 
   /* valgrind complains about this because in some cases the memory areas
      overlap. I switched to memmove. See the memcpy & memmove man pages.
@@ -91,7 +91,7 @@ GetOpt::exchange (char **argv)
   memmove (&argv[first_nonopt], &argv[last_nonopt],
          (optind - last_nonopt) * sizeof (char *));
 
-  memcpy (&argv[first_nonopt + optind - last_nonopt], &temp[0],
+  memcpy (&argv[first_nonopt + optind - last_nonopt], temp.data(),
          nonopts_size);
 
   /* Update records for the slots the non-options now occupy.  */

--- a/HTTPCacheTable.cc
+++ b/HTTPCacheTable.cc
@@ -514,7 +514,7 @@ HTTPCacheTable::create_location(HTTPCacheTable::CacheEntry *entry)
     // mkstemp uses the storage passed to it; must be writable and local.
     // char *templat = new char[hash_dir.size() + 1];
     vector<char> templat(hash_dir.size() + 1);
-    strncpy(&templat[0], hash_dir.c_str(), hash_dir.size() + 1);
+    strncpy(templat.data(), hash_dir.c_str(), hash_dir.size() + 1);
 
     // Open truncated for update. NB: mkstemp() returns a file descriptor.
     // man mkstemp says "... The file is opened with the O_EXCL flag,
@@ -524,14 +524,14 @@ HTTPCacheTable::create_location(HTTPCacheTable::CacheEntry *entry)
     // Make sure that temp files are accessible only by the owner.
     umask(077);
 #endif
-    int fd = MKSTEMP(&templat[0]); // fd mode is 666 or 600 (Unix)
+    int fd = MKSTEMP(templat.data()); // fd mode is 666 or 600 (Unix)
     if (fd < 0) {
         // delete[] templat; templat = 0;
         // close(fd); Calling close() when fd is < 0 is a bad idea! jhrg 7/2/15
         throw Error(internal_error, "The HTTP Cache could not create a file to hold the response; it will not be cached.");
     }
 
-    entry->cachename = &templat[0];
+    entry->cachename = templat.data();
     // delete[] templat; templat = 0;
     close(fd);
 }

--- a/HTTPConnect.cc
+++ b/HTTPConnect.cc
@@ -790,19 +790,19 @@ get_temp_file(FILE *&stream) throw(Error)
 
     vector<char> pathname(dods_temp.length() + 1);
 
-    strncpy(&pathname[0], dods_temp.c_str(), dods_temp.length());
+    strncpy(pathname.data(), dods_temp.c_str(), dods_temp.length());
 
-    DBG(cerr << "pathanme: " << &pathname[0] << " (" << dods_temp.length() + 1 << ")" << endl);
+    DBG(cerr << "pathanme: " << pathname.data() << " (" << dods_temp.length() + 1 << ")" << endl);
 
     // Open truncated for update. NB: mkstemp() returns a file descriptor.
 #if defined(WIN32) || defined(TEST_WIN32_TEMPS)
-    stream = fopen(_mktemp(&pathname[0]), "w+b");
+    stream = fopen(_mktemp(pathname.data()), "w+b");
 #else
     // Make sure that temp files are accessible only by the owner.
     int mask = umask(077);
     if (mask < 0)
         throw Error("Could not set the file creation mask: " + string(strerror(errno)));
-    int fd = mkstemp(&pathname[0]);
+    int fd = mkstemp(pathname.data());
     if (fd < 0)
         throw Error("Could not create a temporary file to store the response: " + string(strerror(errno)));
 
@@ -813,7 +813,7 @@ get_temp_file(FILE *&stream) throw(Error)
     if (!stream)
     	throw Error("Failed to open a temporary file for the data values (" + dods_temp + ")");
 
-    dods_temp = &pathname[0];
+    dods_temp = pathname.data();
     return dods_temp;
 }
 

--- a/RCReader.cc
+++ b/RCReader.cc
@@ -155,46 +155,46 @@ bool RCReader::read_rc_file(const string &pathname)
         vector<char> tempstr(1024);
         int tokenlength;
         while (true) {
-            fpi.getline(&tempstr[0], 1023);
+            fpi.getline(tempstr.data(), 1023);
             if (!fpi.good()) break;
 
-            value = strchr(&tempstr[0], '=');
+            value = strchr(tempstr.data(), '=');
             if (!value) continue;
-            tokenlength = value - &tempstr[0];
+            tokenlength = value - tempstr.data();
             value++;
 
-            if ((strncmp(&tempstr[0], "USE_CACHE", 9) == 0) && tokenlength == 9) {
+            if ((strncmp(tempstr.data(), "USE_CACHE", 9) == 0) && tokenlength == 9) {
                 _dods_use_cache = atoi(value) ? true : false;
             }
-            else if ((strncmp(&tempstr[0], "MAX_CACHE_SIZE", 14) == 0) && tokenlength == 14) {
+            else if ((strncmp(tempstr.data(), "MAX_CACHE_SIZE", 14) == 0) && tokenlength == 14) {
                 _dods_cache_max = atoi(value);
             }
-            else if ((strncmp(&tempstr[0], "MAX_CACHED_OBJ", 14) == 0) && tokenlength == 14) {
+            else if ((strncmp(tempstr.data(), "MAX_CACHED_OBJ", 14) == 0) && tokenlength == 14) {
                 _dods_cached_obj = atoi(value);
             }
-            else if ((strncmp(&tempstr[0], "IGNORE_EXPIRES", 14) == 0) && tokenlength == 14) {
+            else if ((strncmp(tempstr.data(), "IGNORE_EXPIRES", 14) == 0) && tokenlength == 14) {
                 _dods_ign_expires = atoi(value);
             }
-            else if ((strncmp(&tempstr[0], "DEFLATE", 7) == 0) && tokenlength == 7) {
+            else if ((strncmp(tempstr.data(), "DEFLATE", 7) == 0) && tokenlength == 7) {
                 _dods_deflate = atoi(value) ? true : false;
             }
-            else if ((strncmp(&tempstr[0], "CACHE_ROOT", 10) == 0) && tokenlength == 10) {
+            else if ((strncmp(tempstr.data(), "CACHE_ROOT", 10) == 0) && tokenlength == 10) {
                 d_cache_root = value;
                 if (d_cache_root[d_cache_root.length() - 1] != DIR_SEP_CHAR) d_cache_root += string(DIR_SEP_STRING);
             }
-            else if ((strncmp(&tempstr[0], "DEFAULT_EXPIRES", 15) == 0) && tokenlength == 15) {
+            else if ((strncmp(tempstr.data(), "DEFAULT_EXPIRES", 15) == 0) && tokenlength == 15) {
                 _dods_default_expires = atoi(value);
             }
-            else if ((strncmp(&tempstr[0], "ALWAYS_VALIDATE", 15) == 0) && tokenlength == 15) {
+            else if ((strncmp(tempstr.data(), "ALWAYS_VALIDATE", 15) == 0) && tokenlength == 15) {
                 _dods_always_validate = atoi(value);
             }
-            else if ((strncmp(&tempstr[0], "VALIDATE_SSL", 12) == 0) && tokenlength == 12) {
+            else if ((strncmp(tempstr.data(), "VALIDATE_SSL", 12) == 0) && tokenlength == 12) {
                 d_validate_ssl = atoi(value);
             }
-            else if (strncmp(&tempstr[0], "AIS_DATABASE", 12) == 0 && tokenlength == 12) {
+            else if (strncmp(tempstr.data(), "AIS_DATABASE", 12) == 0 && tokenlength == 12) {
                 d_ais_database = value;
             }
-            else if (strncmp(&tempstr[0], "COOKIE_JAR", 10) == 0 && tokenlength == 10) {
+            else if (strncmp(tempstr.data(), "COOKIE_JAR", 10) == 0 && tokenlength == 10) {
                 // if the value of COOKIE_JAR starts with a slash, use it as
                 // is. However, if it does not start with a slash, prefix it
                 // with the directory that contains the .dodsrc file.
@@ -205,7 +205,7 @@ bool RCReader::read_rc_file(const string &pathname)
                     d_cookie_jar = d_rc_file_path.substr(0, d_rc_file_path.find(".dodsrc")) + string(value);
                 } DBG(cerr << "set cookie jar to: " << d_cookie_jar << endl);
             }
-            else if ((strncmp(&tempstr[0], "PROXY_SERVER", 12) == 0) && tokenlength == 12) {
+            else if ((strncmp(tempstr.data(), "PROXY_SERVER", 12) == 0) && tokenlength == 12) {
                 // Setup a proxy server for all requests.
                 // The original syntax was <protocol>,<machine> where the
                 // machine could also contain the user/pass and port info.
@@ -254,7 +254,7 @@ bool RCReader::read_rc_file(const string &pathname)
                     d_dods_proxy_server_port = 80;
                 }
             }
-            else if ((strncmp(&tempstr[0], "NO_PROXY_FOR", 12) == 0) && tokenlength == 12) {
+            else if ((strncmp(tempstr.data(), "NO_PROXY_FOR", 12) == 0) && tokenlength == 12) {
                 // Setup a proxy server for all requests.
                 string no_proxy = value;
                 string::size_type comma = no_proxy.find(',');

--- a/Vector.cc
+++ b/Vector.cc
@@ -1738,7 +1738,7 @@ bool Vector::set_value(string *val, int sz)
 template<typename T>
 bool Vector::set_value_worker(vector<T> &v, int sz)
 {
-    return set_value(&v[0], sz);
+    return set_value(v.data(), sz);
 }
 
 bool Vector::set_value(vector<dods_byte> &val, int sz)

--- a/XDRStreamMarshaller.cc
+++ b/XDRStreamMarshaller.cc
@@ -261,7 +261,7 @@ void XDRStreamMarshaller::put_str(const string &val)
     vector<char> str_buf(size);
 
     try {
-        xdrmem_create(&str_sink, &str_buf[0], size, XDR_ENCODE);
+        xdrmem_create(&str_sink, str_buf.data(), size, XDR_ENCODE);
 
         if (!xdr_setpos(&str_sink, 0))
             throw Error(
@@ -281,7 +281,7 @@ void XDRStreamMarshaller::put_str(const string &val)
         Locker lock(tm->get_mutex(), tm->get_cond(), tm->get_child_thread_count());
 #endif
 
-        d_out.write(&str_buf[0], bytes_written);
+        d_out.write(str_buf.data(), bytes_written);
 
         xdr_destroy(&str_sink);
     }
@@ -386,7 +386,7 @@ void XDRStreamMarshaller::put_vector_end()
     if (pad) {
         vector<char> padding(4, 0); // 4 zeros
 
-        d_out.write(&padding[0], pad);
+        d_out.write(padding.data(), pad);
         if (d_out.fail()) throw Error("Network I/O Error. Could not send vector data padding");
     }
 }

--- a/XDRStreamUnMarshaller.cc
+++ b/XDRStreamUnMarshaller.cc
@@ -189,10 +189,10 @@ void XDRStreamUnMarshaller::get_str(string &val)
         vector<char> buf(i+4);
 
         XDR source;// = new XDR;
-        xdrmem_create(&source, &buf[0], i + 4, XDR_DECODE);
-        memcpy(&buf[0], d_buf, 4);
+        xdrmem_create(&source, buf.data(), i + 4, XDR_DECODE);
+        memcpy(buf.data(), d_buf, 4);
 
-        d_in.read(&buf[0] + 4, i);
+        d_in.read(buf.data() + 4, i);
 
         xdr_setpos( &source, 0);
         if (!xdr_string( &source, &in_tmp, max_str_len)) {
@@ -262,10 +262,10 @@ void XDRStreamUnMarshaller::get_vector(char **val, unsigned int &num, Vector &)
     if (i + 4 > XDR_DAP_BUFF_SIZE) {
     	vector<char> buf(i+4);
         XDR source;
-        xdrmem_create(&source, &buf[0], i + 4, XDR_DECODE);
-        memcpy(&buf[0], d_buf, 4);
+        xdrmem_create(&source, buf.data(), i + 4, XDR_DECODE);
+        memcpy(buf.data(), d_buf, 4);
 
-        d_in.read(&buf[0] + 4, i);
+        d_in.read(buf.data() + 4, i);
         DBG2(cerr << "bytes read: " << d_in.gcount() << endl);
 
         xdr_setpos(&source, 0);
@@ -306,11 +306,11 @@ void XDRStreamUnMarshaller::get_vector(char **val, unsigned int &num, int width,
     if (size > XDR_DAP_BUFF_SIZE) {
     	vector<char> buf(size+4);
         XDR source;
-        xdrmem_create(&source, &buf[0], size + 4, XDR_DECODE);
+        xdrmem_create(&source, buf.data(), size + 4, XDR_DECODE);
         DBG(cerr << "size: " << size << endl);
-        memcpy(&buf[0], d_buf, 4);
+        memcpy(buf.data(), d_buf, 4);
 
-        d_in.read(&buf[0] + 4, size); // +4 for the int already read
+        d_in.read(buf.data() + 4, size); // +4 for the int already read
         DBG(cerr << "bytes read: " << d_in.gcount() << endl);
 
         xdr_setpos(&source, 0);

--- a/chunked_istream.cc
+++ b/chunked_istream.cc
@@ -241,8 +241,8 @@ chunked_inbuf::xsgetn(char* s, std::streamsize num)
 			// small to hold the error message. At this point, there's not much reason
 			// to optimize transport efficiency, however.
 			std::vector<char> message(chunk_size);
-			d_is.read(&message[0], chunk_size);
-			d_error_message = string(&message[0], chunk_size);
+			d_is.read(message.data(), chunk_size);
+			d_error_message = string(message.data(), chunk_size);
 			// leave the buffer and gptr(), ..., in a consistent state (empty)
 			setg(d_buffer, d_buffer, d_buffer);
 	    }

--- a/geo/not_used/GeoConstraint.cc
+++ b/geo/not_used/GeoConstraint.cc
@@ -416,12 +416,12 @@ void GeoConstraint::flip_latitude_within_array(Array &a, int lat_length,
 	int lon_size = array_elem_size * lon_length;
 	int offset = i * lat_lon_size;
 	while (s_lat > -1)
-	    memcpy(&tmp_data[0] + offset + (lat++ * lon_size),
+	    memcpy(tmp_data.data() + offset + (lat++ * lon_size),
 		    d_array_data + offset + (s_lat-- * lon_size),
 		    lon_size);
     }
 
-    memcpy(d_array_data, &tmp_data[0], d_array_data_size);
+    memcpy(d_array_data, tmp_data.data(), d_array_data_size);
 }
 
 /** Reorder the elements in the longitude map so that the longitude constraint no

--- a/mime_util.cc
+++ b/mime_util.cc
@@ -914,12 +914,12 @@ void parse_mime_header(const string &header, string &name, string &value)
     size_t length = header.length() + 1;
     vector<char> s(length);
     //char s[line_length];
-    iss.getline(&s[0], length, ':');
-    name = &s[0];
+    iss.getline(s.data(), length, ':');
+    name = s.data();
 
     iss.ignore(length, ' ');
-    iss.getline(&s[0], length);
-    value = &s[0];
+    iss.getline(s.data(), length);
+    value = s.data();
 
     downcase(name);
     downcase(value);

--- a/old/D4ResponseBuilder.cc
+++ b/old/D4ResponseBuilder.cc
@@ -790,12 +790,12 @@ void D4ResponseBuilder::dataset_constraint_ddx(ostream &out, DDS & dds, Constrai
     uuid_t uu;
     uuid_generate(uu);
     char uuid[37];
-    uuid_unparse(uu, &uuid[0]);
+    uuid_unparse(uu, uuid.data());
     char domain[256];
     if (getdomainname(domain, 255) != 0 || strlen(domain) == 0)
         strncpy(domain, "opendap.org", 255);
 
-    string cid = string(&uuid[0]) + "@" + string(&domain[0]);
+    string cid = string(uuid.data()) + "@" + string(domain.data());
 
     // Send constrained DDX with a data blob reference
     dds.print_xml_writer(out, true, cid);

--- a/tests/TestArray.cc
+++ b/tests/TestArray.cc
@@ -184,7 +184,7 @@ void TestArray::output_values(std::ostream &out)
     for (Dim_iter i = dim_begin(); i != dim_end() && index < dimensions(true); ++i)
         shape[index++] = dimension_size(i, true);
 
-    m_print_array(out, 0, dimensions(true), &shape[0]);
+    m_print_array(out, 0, dimensions(true), shape.data());
 
     //delete[] shape;
     //shape = 0;
@@ -207,7 +207,7 @@ void TestArray::m_build_special_values()
         for (int i = 0; i < array_len; ++i) {
             lat_data[i] = -89 + (180 / array_len) * (i + 1);
         }
-        libdap::set_array_using_double(this, &lat_data[0], array_len);
+        libdap::set_array_using_double(this, lat_data.data(), array_len);
     }
     else if (name().find("lat") != string::npos) {
         int array_len = length();
@@ -216,7 +216,7 @@ void TestArray::m_build_special_values()
         for (int i = 0; i < array_len; ++i) {
             lat_data[i] = 90 - (180 / array_len) * (i + 1);
         }
-        libdap::set_array_using_double(this, &lat_data[0], array_len);
+        libdap::set_array_using_double(this, lat_data.data(), array_len);
     }
     else if (name().find("lon") != string::npos) {
         int array_len = length();
@@ -225,7 +225,7 @@ void TestArray::m_build_special_values()
         for (int i = 0; i < array_len; ++i) {
             lon_data[i] = (360 / array_len) * (i + 1);
         }
-        libdap::set_array_using_double(this, &lon_data[0], array_len);
+        libdap::set_array_using_double(this, lon_data.data(), array_len);
     }
     else {
         throw InternalErr(__FILE__, __LINE__, "Unrecognized name");

--- a/unit-tests/AISMergeTest.cc
+++ b/unit-tests/AISMergeTest.cc
@@ -59,7 +59,7 @@ private:
     {
         string stuff = "";
         char line[256];
-        while (!feof(res) && !ferror(res) && fgets(&line[0], 256, res) != 0)
+        while (!feof(res) && !ferror(res) && fgets(line.data(), 256, res) != 0)
             stuff += line;
 
         return stuff;

--- a/unit-tests/D4MarshallerTest.cc
+++ b/unit-tests/D4MarshallerTest.cc
@@ -88,7 +88,7 @@ class D4MarshallerTest: public CppUnit::TestFixture {
         if (!in) throw Error("Could not open file: " + file);
 
         vector<char> fbuf(len);
-        in.read(&fbuf[0], len);
+        in.read(fbuf.data(), len);
         if (!in) {
             ostringstream oss("Could not read ");
             oss << len << " bytes from file.";
@@ -259,7 +259,7 @@ public:
 
             dsm.reset_checksum();
 
-            dsm.put_opaque_dap4(reinterpret_cast<char*>(&buf[0]), 32768);
+            dsm.put_opaque_dap4(reinterpret_cast<char*>(buf.data()), 32768);
             dsm.put_checksum();
             DBG(cerr << "test_opaque: checksum: " << dsm.get_checksum() << endl);
             dsm.reset_checksum();
@@ -285,7 +285,7 @@ public:
 
             dsm.reset_checksum();
 
-            dsm.put_vector(reinterpret_cast<char*>(&buf1[0]), 32768);
+            dsm.put_vector(reinterpret_cast<char*>(buf1.data()), 32768);
             dsm.put_checksum();
             DBG(cerr << "test_vector: checksum: " << dsm.get_checksum() << endl);
             dsm.reset_checksum();
@@ -294,7 +294,7 @@ public:
             for (int i = 0; i < 32768; ++i)
                 buf2[i] = i % (1 << 9);
 
-            dsm.put_vector(reinterpret_cast<char*>(&buf2[0]), 32768, sizeof(dods_int32));
+            dsm.put_vector(reinterpret_cast<char*>(buf2.data()), 32768, sizeof(dods_int32));
             dsm.put_checksum();
             DBG(cerr << "checksum: " << dsm.get_checksum() << endl);
             dsm.reset_checksum();
@@ -303,7 +303,7 @@ public:
             for (int i = 0; i < 32768; ++i)
                 buf3[i] = i % (1 << 9);
 
-            dsm.put_vector_float64(reinterpret_cast<char*>(&buf3[0]), 32768);
+            dsm.put_vector_float64(reinterpret_cast<char*>(buf3.data()), 32768);
             dsm.put_checksum();
             DBG(cerr << "checksum: " << dsm.get_checksum() << endl);
 
@@ -327,7 +327,7 @@ public:
 
             dsm.reset_checksum();
 
-            dsm.put_varying_vector(reinterpret_cast<char*>(&buf1[0]), 32768);
+            dsm.put_varying_vector(reinterpret_cast<char*>(buf1.data()), 32768);
             dsm.put_checksum();
             DBG(cerr << "test_varying_vector: first checksum: " << dsm.get_checksum() << endl);
             dsm.reset_checksum();
@@ -336,7 +336,7 @@ public:
             for (int i = 0; i < 32768; ++i)
             buf2[i] = i % (1 << 9);
 
-            dsm.put_varying_vector(reinterpret_cast<char*>(&buf2[0]), 32768, sizeof(dods_int32));
+            dsm.put_varying_vector(reinterpret_cast<char*>(buf2.data()), 32768, sizeof(dods_int32));
             dsm.put_checksum();
             DBG(cerr << "second checksum: " << dsm.get_checksum() << endl);
             dsm.reset_checksum();
@@ -345,7 +345,7 @@ public:
             for (int i = 0; i < 32768; ++i)
             buf3[i] = i % (1 << 9);
 
-            dsm.put_varying_vector(reinterpret_cast<char*>(&buf3[0]), 32768, sizeof(dods_float64), dods_float64_c);
+            dsm.put_varying_vector(reinterpret_cast<char*>(buf3.data()), 32768, sizeof(dods_float64), dods_float64_c);
             dsm.put_checksum();
             DBG(cerr << "third checksum: " << dsm.get_checksum() << endl);
 

--- a/unit-tests/D4UnMarshallerTest.cc
+++ b/unit-tests/D4UnMarshallerTest.cc
@@ -301,7 +301,7 @@ public:
             D4StreamUnMarshaller dsm(in, 0);
 
             vector<unsigned char> buf1(32768);
-            dsm.get_vector(reinterpret_cast<char*>(&buf1[0]), 32768);
+            dsm.get_vector(reinterpret_cast<char*>(buf1.data()), 32768);
             for (int i = 0; i < 32768; ++i)
                 CPPUNIT_ASSERT(buf1[i] == i % (1 << 7));
             string ck = dsm.get_checksum_str();
@@ -309,7 +309,7 @@ public:
             CPPUNIT_ASSERT(ck == "199ad7f5" || ck == "199ad7f5");
 
             vector<dods_int32> buf2(32768);
-            dsm.get_vector(reinterpret_cast<char*>(&buf2[0]), 32768, sizeof(dods_int32));
+            dsm.get_vector(reinterpret_cast<char*>(buf2.data()), 32768, sizeof(dods_int32));
             for (int i = 0; i < 32768; ++i)
                 CPPUNIT_ASSERT(buf2[i] == i % (1 << 9));
             ck = dsm.get_checksum_str();
@@ -317,7 +317,7 @@ public:
             CPPUNIT_ASSERT(ck == "5c1bf29f" || ck == "8efd2d3d");
 
             vector<dods_float64> buf3(32768);
-            dsm.get_vector_float64(reinterpret_cast<char*>(&buf3[0]), 32768);
+            dsm.get_vector_float64(reinterpret_cast<char*>(buf3.data()), 32768);
             for (int i = 0; i < 32768; ++i) {
                 if (buf3[i] != i % (1 << 9)) cerr << "buf3[" << i << "]: " << buf3[i] << endl;
                 CPPUNIT_ASSERT(buf3[i] == i % (1 << 9));

--- a/unit-tests/DODSFilterTest.cc
+++ b/unit-tests/DODSFilterTest.cc
@@ -84,7 +84,7 @@ public:
         char *argv_1[] = { (char*) "test_case", (char *) test_file.c_str() };
         df = new DODSFilter(2, argv_1);
 
-        char *argv_1_1[] = { (char*) "test_case", (char *) test_file.c_str(), (char*) "-l", &now_array[0] };
+        char *argv_1_1[] = { (char*) "test_case", (char *) test_file.c_str(), (char*) "-l", now_array.data() };
         df_conditional = new DODSFilter(4, argv_1_1);
 
         // Test missing file
@@ -103,7 +103,7 @@ public:
         test_file = (string) TEST_SRC_DIR + "/server-testsuite/coads.data";
         argv_2[1] = (char *) test_file.c_str();
         argv_2[2] = (char*) "-l";
-        argv_2[3] = &now_array[0];
+        argv_2[3] = now_array.data();
         argv_2[4] = (char*) "-e";
         argv_2[5] = (char*) "u,x,z[0]&grid(u,\"lat<10.0\")";
         argv_2[6] = (char*) "-t";
@@ -115,7 +115,7 @@ public:
         test_file = (string) TEST_SRC_DIR + "/server-testsuite/bears.data";
         argv_2[1] = (char *) test_file.c_str();
         argv_2[2] = (char*) "-l";
-        argv_2[3] = &now_array[0];
+        argv_2[3] = now_array.data();
         argv_2[4] = (char*) "-e";
         argv_2[5] = (char*) "u,x,z[0]&grid(u,\"lat<10.0\")";
         argv_2[6] = (char*) "-t";

--- a/unit-tests/MarshallerTest.cc
+++ b/unit-tests/MarshallerTest.cc
@@ -190,7 +190,7 @@ public:
         db.resize(arr->length());
         for (int i = 0; i < arr->length(); ++i)
             db[i] = 126;
-        arr->value(&db[0]);
+        arr->value(db.data());
 
         // Array of Float32
         a_f32 = new TestFloat32("a_f32");
@@ -204,7 +204,7 @@ public:
         d_f32.resize(arr->length());
         for (int i = 0; i < arr->length(); ++i)
             d_f32[i] = 126.126;
-        arr_f32->value(&d_f32[0]);
+        arr_f32->value(d_f32.data());
 
         // Array of Float64
         a_f64 = new TestFloat64("a_f64");
@@ -218,7 +218,7 @@ public:
         d_f64.resize(arr->length());
         for (int i = 0; i < arr->length(); ++i)
             d_f64[i] = 1260.0126;
-        arr_f64->value(&d_f64[0]);
+        arr_f64->value(d_f64.data());
 
         s = new TestStructure("s");
         s->add_var(i32);
@@ -367,7 +367,7 @@ public:
 
             dods_byte fdb[farr.length() * sizeof(dods_byte)];
             farr.value(fdb);
-            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], farr.length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), farr.length() * sizeof(dods_byte)));
         }
         catch (Error &e) {
             string err = "failed:" + e.get_error_message();
@@ -428,7 +428,7 @@ public:
             fsarr_p->value(fdb);
 
             CPPUNIT_ASSERT(fsarr_p->length() == arr->length());
-            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], fsarr_p->length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), fsarr_p->length() * sizeof(dods_byte)));
         }
         catch (Error &e) {
             string err = "failed:" + e.get_error_message();
@@ -495,7 +495,7 @@ public:
 
             dods_byte fdb[tg.get_array()->length() * sizeof(dods_byte)];
             tg.get_array()->value(fdb);
-            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], tg.get_array()->length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), tg.get_array()->length() * sizeof(dods_byte)));
 
             // Should test the map values here, but skip that for now...
         }
@@ -566,7 +566,7 @@ public:
                 CPPUNIT_ASSERT(arr_p);
                 arr_p->value(fdb);
                 CPPUNIT_ASSERT(arr_p->length() == arr->length());
-                CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], arr_p->length() * sizeof(dods_byte)));
+                CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), arr_p->length() * sizeof(dods_byte)));
                 Sequence *seq_p = dynamic_cast<Sequence *>((*row)[2]);
                 CPPUNIT_ASSERT(seq_p);
                 unsigned int num_rows_sub = seq_p->number_of_rows();
@@ -709,7 +709,7 @@ public:
 
             dods_byte fdb[arr->length() * sizeof(dods_byte)];
             farr.value(fdb);
-            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], farr.length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), farr.length() * sizeof(dods_byte)));
         }
         catch (Error &e) {
             string err = "failed:" + e.get_error_message();
@@ -875,8 +875,8 @@ public:
             CPPUNIT_ASSERT(farr.length() == arr->length());
 
             vector<dods_float32> fd_f32(arr->length());
-            farr.value(&fd_f32[0]);
-            CPPUNIT_ASSERT(!memcmp((void *) &fd_f32[0], (void *) &d_f32[0], farr.length() * sizeof(dods_float32)));
+            farr.value(fd_f32.data());
+            CPPUNIT_ASSERT(!memcmp((void *) fd_f32.data(), (void *) d_f32.data(), farr.length() * sizeof(dods_float32)));
         }
         catch (Error &e) {
             string err = "failed:" + e.get_error_message();
@@ -965,8 +965,8 @@ public:
             CPPUNIT_ASSERT(farr.length() == arr->length());
 
             vector<dods_float64> fd_f64(arr->length());
-            farr.value(&fd_f64[0]);
-            CPPUNIT_ASSERT(!memcmp((void *) &fd_f64[0], (void *) &d_f64[0], farr.length() * sizeof(dods_float64)));
+            farr.value(fd_f64.data());
+            CPPUNIT_ASSERT(!memcmp((void *) fd_f64.data(), (void *) d_f64.data(), farr.length() * sizeof(dods_float64)));
         }
         catch (Error &e) {
             string err = "failed:" + e.get_error_message();
@@ -1076,7 +1076,7 @@ public:
             CPPUNIT_ASSERT(fsarr_p->length() == arr->length());
             dods_byte fdb[fsarr_p->length() * sizeof(dods_byte)];
             fsarr_p->value(fdb);
-            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], fsarr_p->length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), fsarr_p->length() * sizeof(dods_byte)));
         }
         catch (Error &e) {
             string err = "failed:" + e.get_error_message();
@@ -1147,7 +1147,7 @@ public:
 
             dods_byte fdb[tg.get_array()->length() * sizeof(dods_byte)];
             tg.get_array()->value(fdb);
-            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], tg.get_array()->length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), tg.get_array()->length() * sizeof(dods_byte)));
         }
         catch (Error &e) {
             string err = "failed:" + e.get_error_message();
@@ -1220,7 +1220,7 @@ public:
                 CPPUNIT_ASSERT(arr_p);
                 arr_p->value(fdb);
                 CPPUNIT_ASSERT(arr_p->length() == arr->length());
-                CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], arr_p->length() * sizeof(dods_byte)));
+                CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), arr_p->length() * sizeof(dods_byte)));
                 Sequence *seq_p = dynamic_cast<Sequence *>((*row)[2]);
                 CPPUNIT_ASSERT(seq_p);
                 unsigned int num_rows_sub = seq_p->number_of_rows();
@@ -1328,20 +1328,20 @@ public:
 
             dods_byte fdb[arr->length() * sizeof(dods_byte)];
             farr.value(fdb);
-            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], farr.length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), farr.length() * sizeof(dods_byte)));
 
             // now get three more arrays of the same size
             farr.deserialize(um, &dds, false);
             farr.value(fdb);
-            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], farr.length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), farr.length() * sizeof(dods_byte)));
 
             farr.deserialize(um, &dds, false);
             farr.value(fdb);
-            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], farr.length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), farr.length() * sizeof(dods_byte)));
 
             farr.deserialize(um, &dds, false);
             farr.value(fdb);
-            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) &db[0], farr.length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fdb, (void *) db.data(), farr.length() * sizeof(dods_byte)));
         }
         catch (Error &e) {
             string err = "failed:" + e.get_error_message();
@@ -1474,12 +1474,12 @@ public:
 
             dods_float32 fd_32[arr->length() * sizeof(dods_float32)];
             farr.value(fd_32);
-            CPPUNIT_ASSERT(!memcmp((void *) fd_32, (void *) &d_f32[0], farr.length() * sizeof(dods_float32)));
+            CPPUNIT_ASSERT(!memcmp((void *) fd_32, (void *) d_f32.data(), farr.length() * sizeof(dods_float32)));
 
             // now get three more arrays of the same size
             farr.deserialize(um, &dds, false);
             farr.value(fd_32);
-            CPPUNIT_ASSERT(!memcmp((void *) fd_32, (void *) &d_f32[0], farr.length() * sizeof(dods_byte)));
+            CPPUNIT_ASSERT(!memcmp((void *) fd_32, (void *) d_f32.data(), farr.length() * sizeof(dods_byte)));
         }
         catch (Error &e) {
             string err = "failed:" + e.get_error_message();

--- a/unit-tests/ResponseBuilderTest.cc
+++ b/unit-tests/ResponseBuilderTest.cc
@@ -109,7 +109,7 @@ static void parse_datadds_response(istream &in, string &prolog, vector<char> &bl
     in.seekg(pos, in.beg);
 
     blob.reserve(length);
-    in.read(&blob[0], length);
+    in.read(blob.data(), length);
 }
 
 namespace libdap {

--- a/unit-tests/fdiostreamTest.cc
+++ b/unit-tests/fdiostreamTest.cc
@@ -195,7 +195,7 @@ public:
         FILE *fp = fopen(fdiostream_txt.c_str(), "r");
         CPPUNIT_ASSERT("read_test_file_ptr fopen fdiostream.txt" && fp != NULL);
         char word[7];
-        int num = fread(&word[0], 1, 6, fp);
+        int num = fread(word.data(), 1, 6, fp);
         word[6] = '\0';
         DBG(cerr << "first word (" << num << "): " << word << endl);
         CPPUNIT_ASSERT(string(word) == "Output");
@@ -221,7 +221,7 @@ public:
         FILE *fp = fopen(fdiostream_txt.c_str(), "r");
         CPPUNIT_ASSERT("read_test_file_ptr_2 fopen fdiostream.txt" && fp != NULL);
         char word[7];
-        int num = fread(&word[0], 1, 6, fp);
+        int num = fread(word.data(), 1, 6, fp);
         word[6] = '\0';
         DBG(cerr << "first word (" << num << "): " << word << endl);
         CPPUNIT_ASSERT(string(word) == "Output");

--- a/unit-tests/testFile.cc
+++ b/unit-tests/testFile.cc
@@ -30,9 +30,9 @@ read_test_baseline(const string &fn)
     vector<char> buffer(length+1);
 
     // read data as a block:
-    is.read (&buffer[0], length);
+    is.read (buffer.data(), length);
     is.close();
     buffer[length] = '\0';
 
-    return string(&buffer[0]);
+    return string(buffer.data());
 }

--- a/util.cc
+++ b/util.cc
@@ -239,7 +239,7 @@ template<class T> static double *extract_double_array_helper(Array * a)
     int length = a->length();
 
     vector<T> b(length);
-    a->value(&b[0]);    // Extract the values of 'a' to 'b'
+    a->value(b.data());    // Extract the values of 'a' to 'b'
 
     double *dest = new double[length];
     for (int i = 0; i < length; ++i)
@@ -320,7 +320,7 @@ template<class T> static void extract_double_array_helper(Array * a, vector<doub
     int length = a->length();
 
     vector<T> b(length);
-    a->value(&b[0]);    // Extract the values of 'a' to 'b'
+    a->value(b.data());    // Extract the values of 'a' to 'b'
 
     for (int i = 0; i < length; ++i)
         dest[i] = (double) b[i];
@@ -372,7 +372,7 @@ void extract_double_array(Array *a, vector<double> &dest)
     case dods_float32_c:
         return extract_double_array_helper<dods_float32>(a, dest);
     case dods_float64_c:
-        return a->value(&dest[0]);      // no need to copy the values
+        return a->value(dest.data());      // no need to copy the values
         // return extract_double_array_helper<dods_float64>(a, dest);
 
         // Support for DAP4
@@ -1238,18 +1238,18 @@ string open_temp_fstream(ofstream &f, const string &name_template, const string 
     name.push_back('\0');
 
     // Use mkstemp to make and open the temp file atomically
-    int tmpfile = mkstemps(&name[0], suffix.length());
+    int tmpfile = mkstemps(name.data(), suffix.length());
     if (tmpfile == -1)
         throw Error(internal_error, "Could not make a temporary file.");
     // Open the file using C++ ofstream; get a C++ fstream object
-    f.open(&name[0]);
+    f.open(name.data());
     // Close the file descriptor; the file stays open because of the fstream object
     close(tmpfile);
     // Now test that the fstream object is valid
     if (f.fail())
         throw Error(internal_error, "Could not make a temporary file.");
 
-    return string(&name[0]);
+    return string(name.data());
 }
 
 


### PR DESCRIPTION
There are two cases where the pattern was used with strings
where .data() won't work and is not needed (working with char[]
and whre &char[0] will always work).