### PR TITLE
Rhel 8 tirpc

### DIFF
--- a/conf/ox_rhel8_tirpc.m4
+++ b/conf/ox_rhel8_tirpc.m4
@@ -26,11 +26,13 @@ AC_DEFUN([OX_RHEL8_TIRPC], [
 AS_IF([test -f /etc/redhat-release && grep -q '8\.' /etc/redhat-release],
     dnl if this is RHEL8, then we need the tirpc library on CPPFLAGS and LDFLAGS
     [
-        AC_MSG_NOTICE([Found a RHEL 8 or equivalent system])
+        AC_MSG_NOTICE([Found a RHEL 8 or equivalent system...])
         AS_IF([grep -q -v tirpc <<< $CPPFLAGS || grep -q -v tirpc <<< $LDFLAGS],
         dnl if either CPPFLAGS or LDFLAGS lack 'tirpc', error
         [
-            AC_MSG_ERROR([The BES on Redhat Linux 8 requires the tirpc library be included on CPPFLAGS and LDFLAGS])
+            AC_MSG_ERROR([Libdap4 on Redhat Linux 8 requires the tirpc library be included on CPPFLAGS and LDFLAGS])
+        ],
+        [AC_MSG_NOTICE([and CPPFLAGS and LDFLAGS are set])
         ])
     ],
     [

--- a/conf/ox_rhel8_tirpc.m4
+++ b/conf/ox_rhel8_tirpc.m4
@@ -1,0 +1,36 @@
+
+#
+# SYNOPSIS
+#
+#   OX_RHEL8_TIRPC()
+#
+# DESCRIPTION
+#
+# If this system is a RHEL 8 or equivalent, look for the tirpc library on the
+# CPPFLAGS and LDFLAGS environment variables. Print an error message if they are
+# not listed there if this is a RHEL 8 system.
+#
+# LICENSE
+#
+#   Copyright (c) 2022 OPeNDAP
+#   Author: James Gallagher <jgallagher@opendap.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+dnl Check and see if we are building on RHEL8 or the equivalent and if so,
+dnl is the tirpc library available and set up correctly.
+AC_DEFUN([OX_RHEL8_TIRPC], [
+AS_IF([test -f /etc/redhat-release && grep -q '8\.' /etc/redhat-release],
+    dnl if this is RHEL8, then we need the tirpc library on CPPFLAGS and LDFLAGS
+    [
+        AS_IF([grep -q -v tirpc <<< $CPPFLAGS || grep -q -v tirpc <<< $LDFLAGS],
+        dnl if either CPPFLAGS or LDFLAGS lack 'tirpc', error
+        [
+            AC_MSG_ERROR([The BES on Redhat Linux 8 requires the tirpc library be included on CPPFLAGS and LDFLAGS])
+        ])
+    ])
+])
+

--- a/conf/ox_rhel8_tirpc.m4
+++ b/conf/ox_rhel8_tirpc.m4
@@ -26,11 +26,15 @@ AC_DEFUN([OX_RHEL8_TIRPC], [
 AS_IF([test -f /etc/redhat-release && grep -q '8\.' /etc/redhat-release],
     dnl if this is RHEL8, then we need the tirpc library on CPPFLAGS and LDFLAGS
     [
+        AC_MSG_NOTICE([Found a RHEL 8 or equivalent system])
         AS_IF([grep -q -v tirpc <<< $CPPFLAGS || grep -q -v tirpc <<< $LDFLAGS],
         dnl if either CPPFLAGS or LDFLAGS lack 'tirpc', error
         [
             AC_MSG_ERROR([The BES on Redhat Linux 8 requires the tirpc library be included on CPPFLAGS and LDFLAGS])
         ])
+    ],
+    [
+        AC_MSG_NOTICE([Not a RHEL 8 or equivalent system])
     ])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -457,6 +457,11 @@ AC_SUBST([XML2_CFLAGS])
 dnl End old version of XML2 configuration. jhrg 8/31/20
 dnl ********
 
+dnl Check for the RHEL 8 requirement libtirpc and its headers.
+dnl jhrg 6/23/22
+
+OX_RHEL8_TIRPC
+
 AC_CHECK_LIB([pthread], [pthread_kill], 
 	[PTHREAD_LIBS="-lpthread"],
 	[AC_MSG_ERROR([I could not find pthreads])])


### PR DESCRIPTION
This adds a test for the tirpc library when building with RHEL 8. It tests for the presence of the library on CPPFLAGS and LDFLAGS. The hyrax/spatch.sh script will set those automatically on RHEL 8.