### PR TITLE
Modify D4Group::find_var() so it can find D4Groups

### DIFF
--- a/Constructor.cc
+++ b/Constructor.cc
@@ -517,8 +517,7 @@ Constructor::deserialize(D4StreamUnMarshaller &um, DMR &dmr)
 }
 
 void
-Constructor::print_decl(FILE *out, string space, bool print_semi,
-                        bool constraint_info, bool constrained)
+Constructor::print_decl(FILE *out, string space, bool print_semi, bool constraint_info, bool constrained)
 {
     ostringstream oss;
     print_decl(oss, space, print_semi, constraint_info, constrained);
@@ -526,8 +525,7 @@ Constructor::print_decl(FILE *out, string space, bool print_semi,
 }
 
 void
-Constructor::print_decl(ostream &out, string space, bool print_semi,
-                        bool constraint_info, bool constrained)
+Constructor::print_decl(ostream &out, string space, bool print_semi, bool constraint_info, bool constrained)
 {
     if (constrained && !send_p())
         return;

--- a/Constructor.h
+++ b/Constructor.h
@@ -82,7 +82,7 @@ public:
 
     void transform_to_dap4(D4Group *root, Constructor *dest) override;
 
-    std::string FQN() const override ;
+    std::string FQN() const override;
 
     int element_count(bool leaves = false) override;
 

--- a/D4Group.h
+++ b/D4Group.h
@@ -143,8 +143,6 @@ public:
     void print_dap4(XMLWriter &xml, bool constrained = false);
 
     virtual std::vector<BaseType *> *transform_to_dap2(AttrTable *parent_attr_table);
-    //virtual std::vector<BaseType *> *transform_to_dap2(AttrTable *parent_attr_table, bool is_root);
-
 };
 
 } /* namespace libdap */

--- a/D4Group.h
+++ b/D4Group.h
@@ -142,6 +142,14 @@ public:
 
     void print_dap4(XMLWriter &xml, bool constrained = false);
 
+    void print_decl(ostream &out, string space = "    ", bool print_semi = true, bool constraint_info = false,
+                    bool constrained = false) override;
+    void print_decl(FILE *out, string space = "    ", bool print_semi = true, bool constraint_info = false,
+                    bool constrained = false) override;
+
+    void print_val(FILE *out, string space = "", bool print_decl_p = true) override;
+    void print_val(ostream &out, string space = "", bool print_decl_p = true) override;
+
     virtual std::vector<BaseType *> *transform_to_dap2(AttrTable *parent_attr_table);
 };
 

--- a/Vector.cc
+++ b/Vector.cc
@@ -38,8 +38,6 @@
 #include <cstring>
 #include <cassert>
 
-//#define DODS_DEBUG 1
-
 #include <sstream>
 #include <vector>
 #include <algorithm>

--- a/tests/DMRTest.at
+++ b/tests/DMRTest.at
@@ -640,5 +640,16 @@ DMR_PARSE_CE([vol_1_ce_12.xml], [temp[[nasty]]], [vol_1_ce_12.xml.parse_ce_1])
 DMR_PARSE_CE([vol_1_ce_12.xml], [temp[[d1rox%253cscript%253ealert%25281%2529%253c%252fscript%253ed55je=1]]],
     [vol_1_ce_12.xml.parse_ce_2])
 
-# Test revered array indices
+# Test reversed array indices
 DMR_PARSE_CE([test_array_4.xml], [b[[2:1]][[2:3]] ], [test_array_4.xml.error.base], [pass])
+
+# Test projections that only name groups
+DMR_TRANS_CE([vol_1_ce_2.xml], [/inst2], [vol_1_ce_2.xml.1.trans_base], [pass])
+DMR_TRANS_CE([vol_1_ce_2.xml], [inst2], [vol_1_ce_2.xml.1.trans_base], [pass])
+DMR_TRANS_CE([vol_1_ce_2.xml], [/inst2/Point], [vol_1_ce_2.xml.2.trans_base], [pass])
+
+DMR_TRANS_CE([vol_1_ce_13.xml], [/inst2], [vol_1_ce_13.xml.1.trans_base], [pass])
+DMR_TRANS_CE([vol_1_ce_13.xml], [/inst2/inst3], [vol_1_ce_13.xml.2.trans_base], [pass])
+
+DMR_TRANS_CE([vol_1_ce_13.xml], [/attr_only_global], [vol_1_ce_13.xml.3.trans_base], [pass])
+DMR_TRANS_CE([vol_1_ce_13.xml], [/inst2/attr_only], [vol_1_ce_13.xml.4.trans_base], [pass])

--- a/tests/dmr-testsuite/little-endian/vol_1_ce_13.xml.1.trans_base
+++ b/tests/dmr-testsuite/little-endian/vol_1_ce_13.xml.1.trans_base
@@ -1,0 +1,60 @@
+Parse successful
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_13.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Int32 name="u"/>
+    <Int32 name="v"/>
+    <Group name="inst2">
+        <Int32 name="w"/>
+        <Int32 name="x"/>
+        <Group name="attr_only">
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-6666.66</Value>
+            </Attribute>
+        </Group>
+        <Group name="inst3">
+            <Int32 name="y"/>
+            <Int32 name="z"/>
+        </Group>
+    </Group>
+    <Group name="attr_only_global">
+        <Attribute name="_FillValue" type="Float32">
+            <Value>-9999.99</Value>
+        </Attribute>
+    </Group>
+</Dataset>
+
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_13.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Group name="inst2">
+        <Int32 name="w">
+            <Attribute name="DAP4_Checksum_CRC32" type="String">
+                <Value>18df6c9e</Value>
+            </Attribute>
+        </Int32>
+        <Int32 name="x">
+            <Attribute name="DAP4_Checksum_CRC32" type="String">
+                <Value>18df6c9e</Value>
+            </Attribute>
+        </Int32>
+        <Group name="attr_only">
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-6666.66</Value>
+            </Attribute>
+        </Group>
+        <Group name="inst3">
+            <Int32 name="y">
+                <Attribute name="DAP4_Checksum_CRC32" type="String">
+                    <Value>18df6c9e</Value>
+                </Attribute>
+            </Int32>
+            <Int32 name="z">
+                <Attribute name="DAP4_Checksum_CRC32" type="String">
+                    <Value>18df6c9e</Value>
+                </Attribute>
+            </Int32>
+        </Group>
+    </Group>
+</Dataset>
+
+The data:
+{ { 123456789, 123456789 { }{ 123456789, 123456789 } } }

--- a/tests/dmr-testsuite/little-endian/vol_1_ce_13.xml.2.trans_base
+++ b/tests/dmr-testsuite/little-endian/vol_1_ce_13.xml.2.trans_base
@@ -1,0 +1,45 @@
+Parse successful
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_13.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Int32 name="u"/>
+    <Int32 name="v"/>
+    <Group name="inst2">
+        <Int32 name="w"/>
+        <Int32 name="x"/>
+        <Group name="attr_only">
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-6666.66</Value>
+            </Attribute>
+        </Group>
+        <Group name="inst3">
+            <Int32 name="y"/>
+            <Int32 name="z"/>
+        </Group>
+    </Group>
+    <Group name="attr_only_global">
+        <Attribute name="_FillValue" type="Float32">
+            <Value>-9999.99</Value>
+        </Attribute>
+    </Group>
+</Dataset>
+
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_13.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Group name="inst2">
+        <Group name="inst3">
+            <Int32 name="y">
+                <Attribute name="DAP4_Checksum_CRC32" type="String">
+                    <Value>18df6c9e</Value>
+                </Attribute>
+            </Int32>
+            <Int32 name="z">
+                <Attribute name="DAP4_Checksum_CRC32" type="String">
+                    <Value>18df6c9e</Value>
+                </Attribute>
+            </Int32>
+        </Group>
+    </Group>
+</Dataset>
+
+The data:
+{ { { 123456789, 123456789 } } }

--- a/tests/dmr-testsuite/little-endian/vol_1_ce_13.xml.3.trans_base
+++ b/tests/dmr-testsuite/little-endian/vol_1_ce_13.xml.3.trans_base
@@ -1,0 +1,36 @@
+Parse successful
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_13.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Int32 name="u"/>
+    <Int32 name="v"/>
+    <Group name="inst2">
+        <Int32 name="w"/>
+        <Int32 name="x"/>
+        <Group name="attr_only">
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-6666.66</Value>
+            </Attribute>
+        </Group>
+        <Group name="inst3">
+            <Int32 name="y"/>
+            <Int32 name="z"/>
+        </Group>
+    </Group>
+    <Group name="attr_only_global">
+        <Attribute name="_FillValue" type="Float32">
+            <Value>-9999.99</Value>
+        </Attribute>
+    </Group>
+</Dataset>
+
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_13.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Group name="attr_only_global">
+        <Attribute name="_FillValue" type="Float32">
+            <Value>-9999.99</Value>
+        </Attribute>
+    </Group>
+</Dataset>
+
+The data:
+{ { } }

--- a/tests/dmr-testsuite/little-endian/vol_1_ce_13.xml.4.trans_base
+++ b/tests/dmr-testsuite/little-endian/vol_1_ce_13.xml.4.trans_base
@@ -1,0 +1,38 @@
+Parse successful
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_13.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Int32 name="u"/>
+    <Int32 name="v"/>
+    <Group name="inst2">
+        <Int32 name="w"/>
+        <Int32 name="x"/>
+        <Group name="attr_only">
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-6666.66</Value>
+            </Attribute>
+        </Group>
+        <Group name="inst3">
+            <Int32 name="y"/>
+            <Int32 name="z"/>
+        </Group>
+    </Group>
+    <Group name="attr_only_global">
+        <Attribute name="_FillValue" type="Float32">
+            <Value>-9999.99</Value>
+        </Attribute>
+    </Group>
+</Dataset>
+
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_13.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Group name="inst2">
+        <Group name="attr_only">
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-6666.66</Value>
+            </Attribute>
+        </Group>
+    </Group>
+</Dataset>
+
+The data:
+{ { { } } }

--- a/tests/dmr-testsuite/little-endian/vol_1_ce_2.xml.1.trans_base
+++ b/tests/dmr-testsuite/little-endian/vol_1_ce_2.xml.1.trans_base
@@ -1,0 +1,40 @@
+Parse successful
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_2.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Int32 name="u"/>
+    <Int32 name="v"/>
+    <Group name="inst2">
+        <Int32 name="u"/>
+        <Int32 name="v"/>
+        <Structure name="Point">
+            <Int32 name="x"/>
+            <Int32 name="y"/>
+        </Structure>
+    </Group>
+</Dataset>
+
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_2.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Group name="inst2">
+        <Int32 name="u">
+            <Attribute name="DAP4_Checksum_CRC32" type="String">
+                <Value>18df6c9e</Value>
+            </Attribute>
+        </Int32>
+        <Int32 name="v">
+            <Attribute name="DAP4_Checksum_CRC32" type="String">
+                <Value>18df6c9e</Value>
+            </Attribute>
+        </Int32>
+        <Structure name="Point">
+            <Int32 name="x"/>
+            <Int32 name="y"/>
+            <Attribute name="DAP4_Checksum_CRC32" type="String">
+                <Value>114189cb</Value>
+            </Attribute>
+        </Structure>
+    </Group>
+</Dataset>
+
+The data:
+{ { 123456789, 123456789, { 123456789, 123456789 } } }

--- a/tests/dmr-testsuite/little-endian/vol_1_ce_2.xml.2.trans_base
+++ b/tests/dmr-testsuite/little-endian/vol_1_ce_2.xml.2.trans_base
@@ -1,0 +1,30 @@
+Parse successful
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_2.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Int32 name="u"/>
+    <Int32 name="v"/>
+    <Group name="inst2">
+        <Int32 name="u"/>
+        <Int32 name="v"/>
+        <Structure name="Point">
+            <Int32 name="x"/>
+            <Int32 name="y"/>
+        </Structure>
+    </Group>
+</Dataset>
+
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="file:dap4/vol_1_ce_2.xml" dapVersion="4.0" dmrVersion="1.0" name="vol_1_ce_2">
+    <Group name="inst2">
+        <Structure name="Point">
+            <Int32 name="x"/>
+            <Int32 name="y"/>
+            <Attribute name="DAP4_Checksum_CRC32" type="String">
+                <Value>114189cb</Value>
+            </Attribute>
+        </Structure>
+    </Group>
+</Dataset>
+
+The data:
+{ { { 123456789, 123456789 } } }

--- a/tests/dmr-testsuite/vol_1_ce_13.xml
+++ b/tests/dmr-testsuite/vol_1_ce_13.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- nested group example for testing -->
+
+<Dataset name="vol_1_ce_2" dapVersion="4.0" dmrVersion="1.0" xml:base="file:dap4/vol_1_ce_13.xml"
+  xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dap="http://xml.opendap.org/ns/DAP/4.0#">
+  
+  <Int32 name="u"/>
+  <Int32 name="v"/>
+
+  <Group name="inst2">
+    <Int32 name="w"/>
+    <Int32 name="x"/>
+
+    <Group name="attr_only">
+      <Attribute name="_FillValue" type="Float32">
+        <Value>-6666.66</Value>
+      </Attribute>
+    </Group>
+
+    <Group name="inst3">
+      <Int32 name="y"/>
+      <Int32 name="z"/>
+    </Group>
+
+  </Group>
+
+  <Group name="attr_only_global">
+    <Attribute name="_FillValue" type="Float32">
+      <Value>-9999.99</Value>
+    </Attribute>
+  </Group>
+
+
+</Dataset>
+

--- a/unit-tests/D4GroupTest.cc
+++ b/unit-tests/D4GroupTest.cc
@@ -325,7 +325,7 @@ public:
         CPPUNIT_ASSERT_MESSAGE("Looking for a variable that is not there.", its_not_there == nullptr);
 
         // Test finding a group (not a thing in a group). jhrg 8/3/22
-        auto bv_gc_3 = root->find_var("/child/");
+        auto bv_gc_3 = root->find_var("/child");
         CPPUNIT_ASSERT_MESSAGE("Looking for /child/", bv_gc_3 == child);
 
         auto bv_gc_4 = root->find_var("/child/g_child_2");

--- a/unit-tests/D4GroupTest.cc
+++ b/unit-tests/D4GroupTest.cc
@@ -35,18 +35,12 @@
 #include "Byte.h"
 #include "Int64.h"
 #include "Structure.h"
-
 #include "XMLWriter.h"
 #include "debug.h"
 
 #include "testFile.h"
 #include "run_tests_cppunit.h"
 #include "test_config.h"
-
-
-
-
-
 
 using namespace CppUnit;
 using namespace std;
@@ -281,7 +275,7 @@ public:
         load_group_with_scalars(root);
         load_group_with_stuff(root);
 
-        D4Group *child = new D4Group("child");
+        auto child = new D4Group("child");
         load_group_with_scalars(child);
         load_group_with_stuff(child);
         root->add_group(child);
@@ -291,7 +285,7 @@ public:
         // Used add_group() and not add_group_nocopy()
         delete child;
 
-        BaseType *btp = root->find_var("/b");
+        auto btp = root->find_var("/b");
         DBG(cerr << "btp: " << btp << ", name:" << btp->name() << endl);
         DBG(cerr << "btp->parent: " << btp->get_parent() << ", name:" << btp->get_parent()->name() << endl);
         CPPUNIT_ASSERT(btp && btp->name() == "b");
@@ -306,9 +300,9 @@ public:
 
     void test_find_var_2()
     {
-        D4Group *child = new D4Group("child");
-        D4Group *g_child_1 = new D4Group("g_child_1");
-        D4Group *g_child_2 = new D4Group("g_child_2");
+        auto child = new D4Group("child");
+        auto g_child_1 = new D4Group("g_child_1");
+        auto g_child_2 = new D4Group("g_child_2");
 
         load_group_with_scalars(g_child_1);
         load_group_with_stuff(g_child_2);
@@ -322,17 +316,22 @@ public:
         g_child_2->add_var_nocopy(new Byte("byte_var_gc_2"));
 
         auto bv_gc_1 = root->find_var("/child/g_child_1/byte_var_gc_1");
-        CPPUNIT_ASSERT(bv_gc_1);
+        CPPUNIT_ASSERT_MESSAGE("Looking for a variable in /child/g_child_1", bv_gc_1);
 
         auto bv_gc_2 = root->find_var("/child/g_child_2/byte_var_gc_2");
-        CPPUNIT_ASSERT(bv_gc_2);
+        CPPUNIT_ASSERT_MESSAGE("Looking for a variable in /child/g_child_2", bv_gc_2);
 
         auto its_not_there = root->find_var("/child/g_child_2/byte_var_gc_1");
-        CPPUNIT_ASSERT(its_not_there == nullptr);
-        // grp1 = new D4Group("Joey");
-        // grp1->dims()->add_dim_nocopy(new D4Dimension("lat", 1024));
-        // grp1->add_var_nocopy(new Byte("byte_var"));
+        CPPUNIT_ASSERT_MESSAGE("Looking for a variable that is not there.", its_not_there == nullptr);
+
+        // Test finding a group (not a thing in a group). jhrg 8/3/22
+        auto bv_gc_3 = root->find_var("/child/");
+        CPPUNIT_ASSERT_MESSAGE("Looking for /child/", bv_gc_3 == child);
+
+        auto bv_gc_4 = root->find_var("/child/g_child_2");
+        CPPUNIT_ASSERT_MESSAGE("Looking for /child/g_child_2", bv_gc_4 == g_child_2);
     }
+
     void test_print_everything()
     {
         load_group_with_scalars(root);
@@ -445,8 +444,6 @@ public:
         DBG(cerr << "test_fqn_4: " << btp->FQN() << endl);
         CPPUNIT_ASSERT(btp && btp->FQN() == "/child/p.c.b");
     }
-
-
 
     CPPUNIT_TEST_SUITE (D4GroupTest);
 


### PR DESCRIPTION
When a path in a CE specifies a Group, we should be returning all the
variables in that Group. Right now libdap just throws an exception. Once
find_var() retuns the BaseType* to the Group, we should be set to mark
all of the Group's variables as part of the projection.