### PR TITLE
Array manipulation

### DIFF
--- a/Array.h
+++ b/Array.h
@@ -189,6 +189,10 @@ protected:
     unsigned int print_array(ostream &out, unsigned int index,
                              unsigned int dims, unsigned int shape[]);
 
+    std::vector<dimension> &shape(){
+        return _shape;
+    }
+
 public:
     /** A constant iterator used to access the various dimensions of an
         Array.

--- a/Vector.h
+++ b/Vector.h
@@ -166,6 +166,13 @@ public:
 
     virtual BaseType *prototype() const { return d_proto; }
 
+    /**
+     *
+     * @param btp
+     * @return The previous template, calling code is responsible for the returned BaseType lifecycle.
+     */
+    virtual BaseType *set_prototype( BaseType *btp) {  BaseType *orig = d_proto; d_proto = btp; return orig; }
+
     virtual void set_name(const std::string& name);
 
     virtual int element_count(bool leaves);


### PR DESCRIPTION
This PR adds API calls that:

- Add the ability to forcibly replace the prototype/template variable in an Array.
- Adds the ability to get the Arrays internal shape vector

These, together with the existing API, allow an instance of an array (say a DmrppArray) to be "spoofed" to a different type.
