### PR TITLE
Dap4 grid functions

### DIFF
--- a/Array.h
+++ b/Array.h
@@ -178,7 +178,7 @@ private:
     friend class ArrayTest;
     friend class D4Group;
 
-    bool is_dap2_grid();
+
 
 protected:
     void _duplicate(const Array &a);
@@ -213,6 +213,7 @@ public:
     Array &operator=(const Array &rhs);
     virtual BaseType *ptr_duplicate();
 
+    bool is_dap2_grid();
     virtual void transform_to_dap4(D4Group *root, Constructor *container);
     virtual std::vector<BaseType *> *transform_to_dap2(AttrTable *parent_attr_table);
 

--- a/D4Maps.cc
+++ b/D4Maps.cc
@@ -26,6 +26,8 @@
 
 #include "XMLWriter.h"
 #include "InternalErr.h"
+#include "Array.h"
+#include "D4Dimensions.h"
 #include "D4Maps.h"
 
 using namespace libdap;
@@ -36,7 +38,7 @@ D4Map::print_dap4(XMLWriter &xml)
 	if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "Map") < 0)
 		throw InternalErr(__FILE__, __LINE__, "Could not write Map element");
 
-	if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "name", (const xmlChar*)d_name.c_str()) < 0)
+	if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "name", (const xmlChar*)d_array->FQN().c_str()) < 0)
 		throw InternalErr(__FILE__, __LINE__, "Could not write attribute for name");
 
 	if (xmlTextWriterEndElement(xml.get_writer()) < 0)

--- a/D4Maps.cc
+++ b/D4Maps.cc
@@ -38,7 +38,8 @@ D4Map::print_dap4(XMLWriter &xml)
 	if (xmlTextWriterStartElement(xml.get_writer(), (const xmlChar*) "Map") < 0)
 		throw InternalErr(__FILE__, __LINE__, "Could not write Map element");
 
-	if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "name", (const xmlChar*)d_array->FQN().c_str()) < 0)
+	if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*) "name",
+                                    (const xmlChar*)(d_array ? d_array->FQN().c_str(): d_name.c_str())) < 0)
 		throw InternalErr(__FILE__, __LINE__, "Could not write attribute for name");
 
 	if (xmlTextWriterEndElement(xml.get_writer()) < 0)


### PR DESCRIPTION
Minimal changes to libdap to support grid/geogrid function for DAP-4, these are:

- make Array::is_dap2_grid() public method.
- change D4Maps::print_da4() to return FQN() for dimension array, if it exists.