### PR TITLE
Big array unit test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -503,6 +503,16 @@ AS_IF([test x$enable_asan = xyes -a x$has_asan = xyes],
       [AC_MSG_NOTICE([Not building Address Sanitizer version])
        AM_CONDITIONAL([USE_ASAN], [false])])
 
+dnl An optional big array(>4GB) unit test. Since it is resource consuming, turn it off by default.
+AC_ARG_ENABLE([batest], 
+    [AS_HELP_STRING([--enable-batest], [The big array unit test is turned on.  (default: no)])])
+           
+AS_IF([test x$enable_batest = xyes ],
+      [AC_MSG_NOTICE([Adding big array unit test])
+       AM_CONDITIONAL([USE_BA], [true])],
+      [AC_MSG_NOTICE([Not adding big array unit test])
+       AM_CONDITIONAL([USE_BA], [false])])
+
 AC_ARG_ENABLE([leaks],
     [AS_HELP_STRING([--enable-leaks], [Run unit tests on OSX using the 'leaks' if available (default: no)])])
 
@@ -529,6 +539,7 @@ AS_IF([test x$enable_developer = xyes],
       [AC_MSG_NOTICE([Not building developer version])
        AM_CONDITIONAL([BUILD_DEVELOPER], [false])
        AC_DEFINE([NDEBUG], [1], [Define this to suppres assert() calls.])])
+
 
 AC_ARG_ENABLE([coverage],
     [AS_HELP_STRING([--enable-coverage], [Build so tests emit coverage data and enable coverage target (default: no)])])

--- a/unit-tests/BigArrayTest.cc
+++ b/unit-tests/BigArrayTest.cc
@@ -47,7 +47,6 @@ namespace libdap {
 
 class BigArrayTest: public TestFixture {
 private:
-    Byte *d_uint8 = nullptr;
     uint64_t num_eles;
     vector<unsigned char>buf_int8;
 
@@ -107,10 +106,6 @@ public:
 
         // Retrieve the array value via buf2val
         d4_ar_uint8.buf2val(&d4_ar_val_ptr);
-#if 0
-        cout<<"the first value buf2val is "<<(int)(d4_ar_val[0]) <<endl;
-        cout<<"the middle value buf2val is "<<(int)(d4_ar_val[num_eles/2]) <<endl;
-#endif
         DBG(cerr<<"DAP4 buf2val: The first value is "<<(int)(d4_ar_val[0]) <<endl);
         DBG(cerr<<"DAP4 buf2val: The middle value is "<<(int)(d4_ar_val[num_eles/2]) <<endl);
         DBG(cerr<<"DAP4 buf2val: The last value is "<<(int)(d4_ar_val[num_eles-1]) <<endl);
@@ -136,10 +131,6 @@ public:
 
         // Retrieve the array value via value()
         d4_ar_uint8.value(d4_ar_val.data());
-#if 0
-        cout<<"the first value via value() is "<<(int)(d4_ar_val[0]) <<endl;
-        cout<<"the middle value via value() is "<<(int)(d4_ar_val[num_eles/2]) <<endl;
-#endif
         DBG(cerr<<"DAP4 value(): The first value is "<<(int)(d4_ar_val[0]) <<endl);
         DBG(cerr<<"DAP4 value(): The middle value is "<<(int)(d4_ar_val[num_eles/2]) <<endl);
         DBG(cerr<<"DAP4 value(): The last value is "<<(int)(d4_ar_val[num_eles-1]) <<endl);
@@ -164,10 +155,6 @@ public:
 
         // Retrieve the array value via value()
         d_ar_uint8.value(d_ar_val.data());
-#if 0
-        cout<<"the first value buf2val is "<<(int)(d_ar_val[0]) <<endl;
-        cout<<"the middle value buf2val is "<<(int)(d_ar_val[num_eles/2]) <<endl;
-#endif
         DBG(cerr<<"DAP2 value() via set_value(): The first value is "<<(int)(d_ar_val[0]) <<endl);
         DBG(cerr<<"DAP2 value() via set_value(): The middle value is "<<(int)(d_ar_val[num_eles/2]) <<endl);
         DBG(cerr<<"DAP2 value() via set_value(): The last value is "<<(int)(d_ar_val[num_eles-1]) <<endl);

--- a/unit-tests/BigArrayTest.cc
+++ b/unit-tests/BigArrayTest.cc
@@ -59,6 +59,8 @@ private:
 
     Int16 *d_int16 = nullptr;
     Byte *d_uint8 = nullptr;
+    uint64_t num_eles;
+    vector<unsigned char>buf_int8;
 
     
 public:
@@ -68,47 +70,25 @@ public:
 
     void setUp()
     {
-        d_int16 = new Int16("Int16");
-        DBG(cerr << "d_int16: " << d_int16 << endl);
-        d_cardinal = new Array("Array_of_Int16", d_int16);
-        uint64_t num_eles=1024*1024*1024*4;
-        auto d4_dim = new D4Dimension("dimension",num_eles);
-        d_cardinal->append_dim(d4_dim);
-        vector<short> buffer;
-        buffer.resize(num_eles);
-        buffer[0]=-32768;
-        buffer[num_eles-1]=32767;
-        d_cardinal->set_value((dods_int16*)buffer.data(),num_eles);
-        delete d4_dim;
-        delete d_int16;
-        d_int16 = 0;
+        num_eles=1024*1024*1024;
+        num_eles = num_eles*5;
+        //num_eles = 2;
+        buf_int8.resize(num_eles);
 
 #if 0
-        d_int16 = new Int16("Int16");
-
-        DBG(cerr << "d_int16: " << d_int16 << endl);
-        d_cardinal = new Array("Array_of_Int16", d_int16);
-        uint64_t num_eles=1024*1024*1024*4;
-        d_cardinal->append_dim(4, "dimension");
-        dods_int16 buffer[4] = { 0, 1, 2, 3 };
-        d_cardinal->val2buf(buffer);
-
-        // Added to test if Arrays with DAP4 protos will have is_dap4() == true. jhrg 7/27/22
-        Int64 i64("");
-        d_card_dap4 = new Array("Array_of_Int64", &i64);
-        d_card_dap4->append_dim(4, "dimension");
-        dods_int64 buffer64[4] = { 0, 1, 2, 3 };
-        d_card_dap4->val2buf(buffer64);
-
-        delete d_int16;
-        d_int16 = 0;
+        auto d4_dim_byte = new D4Dimension("dimension",num_eles);
+        d_cardinal_byte->append_dim(d4_dim_byte);
+        vector<unsigned char> buffer_u8;
+        buffer_u8.resize(num_eles);
+        d_cardinal_byte->val2buf(buffer_u8.data());
+        delete d4_dim_byte;
+        delete d_uint8;
 #endif
+ 
     }
 
     void tearDown()
     {
-        delete d_cardinal;
-        delete d_card_dap4;
     }
 
 
@@ -117,17 +97,6 @@ public:
     CPPUNIT_TEST (cons_test);
 #if 0
     CPPUNIT_TEST (test_is_dap4_1);
-    CPPUNIT_TEST (test_is_dap4_2);
-    CPPUNIT_TEST (test_is_dap4_3);
-    CPPUNIT_TEST (test_is_dap4_4);
-    CPPUNIT_TEST (assignment_test_1);
-    CPPUNIT_TEST (assignment_test_2);
-    CPPUNIT_TEST (assignment_test_3);
-    CPPUNIT_TEST (prepend_dim_test);
-    CPPUNIT_TEST (prepend_dim_2_test);
-    CPPUNIT_TEST (clear_dims_test);
-    CPPUNIT_TEST (error_handling_test);
-    CPPUNIT_TEST (error_handling_2_test);
     CPPUNIT_TEST (duplicate_cardinal_test);
 #endif
 
@@ -135,8 +104,15 @@ public:
 
     void cons_test()
     {
-        Array a1 = Array("a", "b", d_int16, true);
-        CPPUNIT_ASSERT(a1.name() == "a");
+
+        unique_ptr<Byte> d_uint8(new Byte("Byte"));
+        Array d_ar_uint8 = Array("Byte_array",d_uint8.get());
+        unique_ptr<D4Dimension> d4_dim_byte(new D4Dimension("dimension",num_eles));
+        d_ar_uint8.append_dim(d4_dim_byte.get());
+        d_ar_uint8.val2buf(buf_int8.data());
+        
+
+        //CPPUNIT_ASSERT(a1.name() == "a");
     }
 
     void test_is_dap4_1() {

--- a/unit-tests/BigArrayTest.cc
+++ b/unit-tests/BigArrayTest.cc
@@ -35,10 +35,6 @@
 
 #include "Array.h"
 #include "Byte.h"
-#include "Int16.h"
-#include "Float32.h"
-#include "Int64.h"
-#include "D4Enum.h"
 #include "D4Dimensions.h"
 
 #include "run_tests_cppunit.h"
@@ -64,24 +60,20 @@ public:
     void setUp()
     {
         num_eles=1024*1024*1024;
-        //num_eles=num_eles*2;
         num_eles = num_eles*5;
+
+        // Uncomment this #if 0 block to test a trivial small array case.
+#if 0
         num_eles = 4;
+#endif 
         buf_int8.resize(num_eles);
         buf_int8[0] = 0;
-        //cout<<"buf_int8 0 is "<<(int)(buf_int8[0]) <<endl;
         buf_int8[num_eles/2] = 128;
         buf_int8[num_eles-1] = 255;
 
-#if 0
-        auto d4_dim_byte = new D4Dimension("dimension",num_eles);
-        d_cardinal_byte->append_dim(d4_dim_byte);
-        vector<unsigned char> buffer_u8;
-        buffer_u8.resize(num_eles);
-        d_cardinal_byte->val2buf(buffer_u8.data());
-        delete d4_dim_byte;
-        delete d_uint8;
-#endif
+        DBG(cerr<<"Input buffer: The first value is "<<(int)(buf_int8[0]) <<endl);
+        DBG(cerr<<"Input buffer: The middle value is "<<(int)(buf_int8[num_eles/2]) <<endl);
+        DBG(cerr<<"Input buffer: The last value is "<<(int)(buf_int8[num_eles-1]) <<endl);
  
     }
 
@@ -105,17 +97,24 @@ public:
         Array d4_ar_uint8 = Array("Byte_array",d_uint8.get());
         unique_ptr<D4Dimension> d4_dim_byte(new D4Dimension("dimension",num_eles));
         d4_ar_uint8.append_dim(d4_dim_byte.get());
+
+        // Set the array value via val2buf
         d4_ar_uint8.val2buf(buf_int8.data());
-        cout<<"the first value is "<<(int)(buf_int8[0]) <<endl;
-        cout<<"the middle value is "<<(int)(buf_int8[num_eles/2]) <<endl;
+
         vector<unsigned char>d4_ar_val;
         d4_ar_val.resize(num_eles);
-
-        // The following doesn't work for 64-bit integer
         void* d4_ar_val_ptr = (void*)(d4_ar_val.data());    
+
+        // Retrieve the array value via buf2val
         d4_ar_uint8.buf2val(&d4_ar_val_ptr);
+#if 0
         cout<<"the first value buf2val is "<<(int)(d4_ar_val[0]) <<endl;
         cout<<"the middle value buf2val is "<<(int)(d4_ar_val[num_eles/2]) <<endl;
+#endif
+        DBG(cerr<<"DAP4 buf2val: The first value is "<<(int)(d4_ar_val[0]) <<endl);
+        DBG(cerr<<"DAP4 buf2val: The middle value is "<<(int)(d4_ar_val[num_eles/2]) <<endl);
+        DBG(cerr<<"DAP4 buf2val: The last value is "<<(int)(d4_ar_val[num_eles-1]) <<endl);
+
         CPPUNIT_ASSERT(buf_int8[0] == d4_ar_val[0]);
         CPPUNIT_ASSERT(buf_int8[num_eles/2] == d4_ar_val[num_eles/2]);
         CPPUNIT_ASSERT(buf_int8[num_eles-1] == d4_ar_val[num_eles-1]);
@@ -128,16 +127,23 @@ public:
         Array d4_ar_uint8 = Array("Byte_array",d_uint8.get());
         unique_ptr<D4Dimension> d4_dim_byte(new D4Dimension("dimension",num_eles));
         d4_ar_uint8.append_dim(d4_dim_byte.get());
+
+        // Set the array value via val2buf
         d4_ar_uint8.val2buf(buf_int8.data());
-        cout<<"the first value is "<<(int)(buf_int8[0]) <<endl;
-        cout<<"the middle value is "<<(int)(buf_int8[num_eles/2]) <<endl;
+
         vector<unsigned char>d4_ar_val;
         d4_ar_val.resize(num_eles);
 
-        // The following doesn't work for 64-bit integer
+        // Retrieve the array value via value()
         d4_ar_uint8.value(d4_ar_val.data());
-        cout<<"the first value buf2val is "<<(int)(d4_ar_val[0]) <<endl;
-        cout<<"the middle value buf2val is "<<(int)(d4_ar_val[num_eles/2]) <<endl;
+#if 0
+        cout<<"the first value via value() is "<<(int)(d4_ar_val[0]) <<endl;
+        cout<<"the middle value via value() is "<<(int)(d4_ar_val[num_eles/2]) <<endl;
+#endif
+        DBG(cerr<<"DAP4 value(): The first value is "<<(int)(d4_ar_val[0]) <<endl);
+        DBG(cerr<<"DAP4 value(): The middle value is "<<(int)(d4_ar_val[num_eles/2]) <<endl);
+        DBG(cerr<<"DAP4 value(): The last value is "<<(int)(d4_ar_val[num_eles-1]) <<endl);
+
         CPPUNIT_ASSERT(buf_int8[0] == d4_ar_val[0]);
         CPPUNIT_ASSERT(buf_int8[num_eles/2] == d4_ar_val[num_eles/2]);
         CPPUNIT_ASSERT(buf_int8[num_eles-1] == d4_ar_val[num_eles-1]);
@@ -149,43 +155,28 @@ public:
         Array d_ar_uint8 = Array("Byte_array",d_uint8.get());
         d_ar_uint8.append_dim(2);
         d_ar_uint8.append_dim(num_eles/2);
+
+        // Set the array value via set_value()
         d_ar_uint8.set_value((dods_byte *)buf_int8.data(),num_eles);
-        cout<<"the first value is "<<(int)(buf_int8[0]) <<endl;
-        cout<<"the middle value is "<<(int)(buf_int8[num_eles/2]) <<endl;
+
         vector<unsigned char>d_ar_val;
         d_ar_val.resize(num_eles);
+
+        // Retrieve the array value via value()
         d_ar_uint8.value(d_ar_val.data());
+#if 0
         cout<<"the first value buf2val is "<<(int)(d_ar_val[0]) <<endl;
         cout<<"the middle value buf2val is "<<(int)(d_ar_val[num_eles/2]) <<endl;
+#endif
+        DBG(cerr<<"DAP2 value() via set_value(): The first value is "<<(int)(d_ar_val[0]) <<endl);
+        DBG(cerr<<"DAP2 value() via set_value(): The middle value is "<<(int)(d_ar_val[num_eles/2]) <<endl);
+        DBG(cerr<<"DAP2 value() via set_value(): The last value is "<<(int)(d_ar_val[num_eles-1]) <<endl);
+
         CPPUNIT_ASSERT(buf_int8[0] == d_ar_val[0]);
         CPPUNIT_ASSERT(buf_int8[num_eles/2] == d_ar_val[num_eles/2]);
         CPPUNIT_ASSERT(buf_int8[num_eles-1] == d_ar_val[num_eles-1]);
  
     }
-#if 0
-
-    void error_handling_test()
-    {
-        Array a1 = Array("a", d_int16);
-        Array::Dim_iter i = a1.dim_begin();
-        string msg;
-        CPPUNIT_ASSERT_THROW(a1.dimension_name(i), InternalErr);
-        CPPUNIT_ASSERT(!a1.check_semantics(msg));
-    }
-
-    void error_handling_2_test()
-    {
-        Array a1 = Array("a", d_int16);
-        a1.append_dim(2, "dim_a");
-        Array::Dim_iter i = a1.dim_begin();
-        CPPUNIT_ASSERT(a1.dimension_size(i) == 2);
-        CPPUNIT_ASSERT_THROW(a1.add_constraint(i, 2, 1, 1), Error);
-        CPPUNIT_ASSERT_THROW(a1.add_constraint(i, 0, 1, 2), Error);
-        CPPUNIT_ASSERT_THROW(a1.add_constraint(i, 0, 3, 1), Error);
-    }
-
-
-#endif
 
 };
 

--- a/unit-tests/BigArrayTest.cc
+++ b/unit-tests/BigArrayTest.cc
@@ -71,6 +71,24 @@ public:
         d_int16 = new Int16("Int16");
         DBG(cerr << "d_int16: " << d_int16 << endl);
         d_cardinal = new Array("Array_of_Int16", d_int16);
+        uint64_t num_eles=1024*1024*1024*4;
+        auto d4_dim = new D4Dimension("dimension",num_eles);
+        d_cardinal->append_dim(d4_dim);
+        vector<short> buffer;
+        buffer.resize(num_eles);
+        buffer[0]=-32768;
+        buffer[num_eles-1]=32767;
+        d_cardinal->set_value((dods_int16*)buffer.data(),num_eles);
+        delete d4_dim;
+        delete d_int16;
+        d_int16 = 0;
+
+#if 0
+        d_int16 = new Int16("Int16");
+
+        DBG(cerr << "d_int16: " << d_int16 << endl);
+        d_cardinal = new Array("Array_of_Int16", d_int16);
+        uint64_t num_eles=1024*1024*1024*4;
         d_cardinal->append_dim(4, "dimension");
         dods_int16 buffer[4] = { 0, 1, 2, 3 };
         d_cardinal->val2buf(buffer);
@@ -84,6 +102,7 @@ public:
 
         delete d_int16;
         d_int16 = 0;
+#endif
     }
 
     void tearDown()

--- a/unit-tests/BigArrayTest.cc
+++ b/unit-tests/BigArrayTest.cc
@@ -49,31 +49,29 @@ using namespace std;
 
 namespace libdap {
 
-class ArrayTest: public TestFixture {
+class BigArrayTest: public TestFixture {
 private:
-    Array *d_cardinal = nullptr;
-    Array *d_card_dap4 = nullptr;
-
-    Array *d_cardinal_byte = nullptr;
-    Array *d_card_dap4_byte = nullptr;
-
-    Int16 *d_int16 = nullptr;
     Byte *d_uint8 = nullptr;
     uint64_t num_eles;
     vector<unsigned char>buf_int8;
 
     
 public:
-    ArrayTest() = default;
+    BigArrayTest() = default;
 
-    ~ArrayTest() = default;
+    ~BigArrayTest() = default;
 
     void setUp()
     {
         num_eles=1024*1024*1024;
+        //num_eles=num_eles*2;
         num_eles = num_eles*5;
-        //num_eles = 2;
+        num_eles = 4;
         buf_int8.resize(num_eles);
+        buf_int8[0] = 0;
+        //cout<<"buf_int8 0 is "<<(int)(buf_int8[0]) <<endl;
+        buf_int8[num_eles/2] = 128;
+        buf_int8[num_eles-1] = 255;
 
 #if 0
         auto d4_dim_byte = new D4Dimension("dimension",num_eles);
@@ -92,137 +90,79 @@ public:
     }
 
 
-    CPPUNIT_TEST_SUITE (ArrayTest);
+    CPPUNIT_TEST_SUITE (BigArrayTest);
 
-    CPPUNIT_TEST (cons_test);
-#if 0
-    CPPUNIT_TEST (test_is_dap4_1);
-    CPPUNIT_TEST (duplicate_cardinal_test);
-#endif
+    CPPUNIT_TEST (dap4_val2buf_buf2val);
+    CPPUNIT_TEST (dap4_val2buf_value);
+    CPPUNIT_TEST (dap2_set_value);
 
     CPPUNIT_TEST_SUITE_END();
 
-    void cons_test()
+    void dap4_val2buf_buf2val()
     {
 
         unique_ptr<Byte> d_uint8(new Byte("Byte"));
-        Array d_ar_uint8 = Array("Byte_array",d_uint8.get());
+        Array d4_ar_uint8 = Array("Byte_array",d_uint8.get());
         unique_ptr<D4Dimension> d4_dim_byte(new D4Dimension("dimension",num_eles));
-        d_ar_uint8.append_dim(d4_dim_byte.get());
-        d_ar_uint8.val2buf(buf_int8.data());
-        
+        d4_ar_uint8.append_dim(d4_dim_byte.get());
+        d4_ar_uint8.val2buf(buf_int8.data());
+        cout<<"the first value is "<<(int)(buf_int8[0]) <<endl;
+        cout<<"the middle value is "<<(int)(buf_int8[num_eles/2]) <<endl;
+        vector<unsigned char>d4_ar_val;
+        d4_ar_val.resize(num_eles);
 
-        //CPPUNIT_ASSERT(a1.name() == "a");
+        // The following doesn't work for 64-bit integer
+        void* d4_ar_val_ptr = (void*)(d4_ar_val.data());    
+        d4_ar_uint8.buf2val(&d4_ar_val_ptr);
+        cout<<"the first value buf2val is "<<(int)(d4_ar_val[0]) <<endl;
+        cout<<"the middle value buf2val is "<<(int)(d4_ar_val[num_eles/2]) <<endl;
+        CPPUNIT_ASSERT(buf_int8[0] == d4_ar_val[0]);
+        CPPUNIT_ASSERT(buf_int8[num_eles/2] == d4_ar_val[num_eles/2]);
+        CPPUNIT_ASSERT(buf_int8[num_eles-1] == d4_ar_val[num_eles-1]);
     }
 
-    void test_is_dap4_1() {
-        DBG(d_card_dap4->dump(cerr));
-        CPPUNIT_ASSERT_MESSAGE("This Array should register as DAP4", d_card_dap4->is_dap4());
-    }
-
-    void test_is_dap4_2() {
-        DBG(d_cardinal->dump(cerr));
-        CPPUNIT_ASSERT_MESSAGE("This Array should not register as DAP4", !d_cardinal->is_dap4());
-    }
-
-    void test_is_dap4_3() {
-        // An array Enum is always DAP4, even when the underlying type of the enum is not
-        D4Enum enum16("", dods_int16_c);
-        unique_ptr<Array> enum_array_dap4(new Array("Array_of_Enum", &enum16));
-        enum_array_dap4->append_dim(4, "dimension");
-        dods_int16 buffer16[4] = { 0, 1, 2, 3 };
-        enum_array_dap4->val2buf(buffer16);
-
-        DBG(enum_array_dap4->dump(cerr));
-        CPPUNIT_ASSERT_MESSAGE("This Array should register as DAP4", enum_array_dap4->is_dap4());
-    }
-
-    void test_is_dap4_4() {
-        D4Enum enum64("", dods_int64_c);
-        unique_ptr<Array> enum_array_dap4(new Array("Array_of_Enum", &enum64));
-        enum_array_dap4->append_dim(4, "dimension");
-        dods_int64 buffer64[4] = { 0, 1, 2, 3 };
-        enum_array_dap4->val2buf(buffer64);
-
-        DBG(enum_array_dap4->dump(cerr));
-        CPPUNIT_ASSERT_MESSAGE("This Array should register as DAP4", enum_array_dap4->is_dap4());
-    }
-
-    void assignment_test_1()
+    void dap4_val2buf_value()
     {
-        // Are fields from the object copied by the assignment
-        Array a1 = Array("a", d_int16);
-        a1.append_dim(17, "bob");
-        CPPUNIT_ASSERT(a1.dimension_size(a1.dim_begin()) == 17);
-        a1 = *d_cardinal;
-        CPPUNIT_ASSERT(a1.dimension_size(a1.dim_begin()) == 4);
+
+        unique_ptr<Byte> d_uint8(new Byte("Byte"));
+        Array d4_ar_uint8 = Array("Byte_array",d_uint8.get());
+        unique_ptr<D4Dimension> d4_dim_byte(new D4Dimension("dimension",num_eles));
+        d4_ar_uint8.append_dim(d4_dim_byte.get());
+        d4_ar_uint8.val2buf(buf_int8.data());
+        cout<<"the first value is "<<(int)(buf_int8[0]) <<endl;
+        cout<<"the middle value is "<<(int)(buf_int8[num_eles/2]) <<endl;
+        vector<unsigned char>d4_ar_val;
+        d4_ar_val.resize(num_eles);
+
+        // The following doesn't work for 64-bit integer
+        d4_ar_uint8.value(d4_ar_val.data());
+        cout<<"the first value buf2val is "<<(int)(d4_ar_val[0]) <<endl;
+        cout<<"the middle value buf2val is "<<(int)(d4_ar_val[num_eles/2]) <<endl;
+        CPPUNIT_ASSERT(buf_int8[0] == d4_ar_val[0]);
+        CPPUNIT_ASSERT(buf_int8[num_eles/2] == d4_ar_val[num_eles/2]);
+        CPPUNIT_ASSERT(buf_int8[num_eles-1] == d4_ar_val[num_eles-1]);
     }
 
-    void assignment_test_2()
+    void dap2_set_value()
     {
-        // Self-assignment; are objects changed by the assignment?
-        Array a1 = Array("a", d_int16);
-        Array *before = &a1;
-        a1 = a1;
-        Array *after = &a1;
-        CPPUNIT_ASSERT_MESSAGE("The pointers should be the same", before == after);
+        unique_ptr<Byte> d_uint8(new Byte("Byte"));
+        Array d_ar_uint8 = Array("Byte_array",d_uint8.get());
+        d_ar_uint8.append_dim(2);
+        d_ar_uint8.append_dim(num_eles/2);
+        d_ar_uint8.set_value((dods_byte *)buf_int8.data(),num_eles);
+        cout<<"the first value is "<<(int)(buf_int8[0]) <<endl;
+        cout<<"the middle value is "<<(int)(buf_int8[num_eles/2]) <<endl;
+        vector<unsigned char>d_ar_val;
+        d_ar_val.resize(num_eles);
+        d_ar_uint8.value(d_ar_val.data());
+        cout<<"the first value buf2val is "<<(int)(d_ar_val[0]) <<endl;
+        cout<<"the middle value buf2val is "<<(int)(d_ar_val[num_eles/2]) <<endl;
+        CPPUNIT_ASSERT(buf_int8[0] == d_ar_val[0]);
+        CPPUNIT_ASSERT(buf_int8[num_eles/2] == d_ar_val[num_eles/2]);
+        CPPUNIT_ASSERT(buf_int8[num_eles-1] == d_ar_val[num_eles-1]);
+ 
     }
-
-    // This tests that the assignment operator defined in Array correctly copies
-    // information held in a parent class (Vector). jhrg 2/9/22
-    void assignment_test_3()
-    {
-        // Array copies the proto pointer and manages the storage
-#if 0       
-        unique_ptr<Float32> f32(new Float32("float_proto"));
-        Array a1 = Array("a", f32.get());
-#endif
-        auto f32_ptr = new Float32("float_proto");
-        Array a1 = Array("a", f32_ptr);
-	delete f32_ptr;
-	
-        CPPUNIT_ASSERT_MESSAGE("The type of a1.var() should be dods_float32", a1.var()->type() == dods_float32_c);
-        a1 = *d_cardinal;
-        CPPUNIT_ASSERT_MESSAGE("The type of a1.var() should now be dods_int16_c", a1.var()->type() == dods_int16_c);
-    }
-
-    void prepend_dim_test()
-    {
-        Array a1 = Array("a", d_int16);
-        Array::Dim_iter i = a1.dim_begin();
-        CPPUNIT_ASSERT(a1.dimension_size(i) == 0);
-        a1.prepend_dim(2, "dim_a");
-        i = a1.dim_begin();
-        CPPUNIT_ASSERT(a1.dimension_size(i) == 2);
-        a1.prepend_dim(3, "dim_b");
-    }
-
-    void prepend_dim_2_test()
-    {
-        Array a1 = Array("a", d_int16);
-        string expected_name[2] = {"dim_b", "myDim"};
-        int j = 0;
-        D4Dimensions *dims = new D4Dimensions();
-        D4Dimension *d = new D4Dimension("dim_b", 2, dims);
-        a1.prepend_dim(2, "dim_a");
-        a1.prepend_dim(d);
-        a1.rename_dim("dim_a", "myDim");
-        for (Array::Dim_iter i = a1.dim_begin(); i != a1.dim_end(); i++, j++) {
-            CPPUNIT_ASSERT(a1.dimension_name(i) == expected_name[j]);
-        }
-        delete dims;
-        delete d;
-    }
-
-    void clear_dims_test()
-    {
-        Array a1 = Array("a", d_int16);
-        a1.prepend_dim(2, "dim_a");
-        a1.prepend_dim(3, "dim_b");
-        a1.clear_all_dims();
-        Array::Dim_iter i = a1.dim_begin();
-        CPPUNIT_ASSERT(a1.dimension_size(i) == 0);
-    }
+#if 0
 
     void error_handling_test()
     {
@@ -245,40 +185,15 @@ public:
     }
 
 
-    void duplicate_cardinal_test()
-    {
-        Array::Dim_iter i = d_cardinal->dim_begin();
-        CPPUNIT_ASSERT(d_cardinal->dimension_size(i) == 4);
-        dods_int16 *b = new dods_int16[4];
-        d_cardinal->buf2val((void**) &b);
-        for (int i = 0; i < 4; ++i) {
-            CPPUNIT_ASSERT(b[i] == i);
-            DBG(cerr << "b[" << i << "]: " << b[i] << endl);
-        }
-        delete[] b;
-        b = 0;
-
-        Array a = *d_cardinal;
-        i = a.dim_begin();
-        CPPUNIT_ASSERT(a.dimension_size(i) == 4);
-
-        dods_int16 *b2 = new dods_int16[4];
-        d_cardinal->buf2val((void**) &b2);
-        for (int i = 0; i < 4; ++i) {
-            CPPUNIT_ASSERT(b2[i] == i);
-            DBG(cerr << "b2[" << i << "]: " << b2[i] << endl);
-        }
-        delete[] b2;
-        b2 = 0;
-    }
+#endif
 
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION (ArrayTest);
+CPPUNIT_TEST_SUITE_REGISTRATION (BigArrayTest);
 
 } // namespace libdap
 
 int main(int argc, char *argv[])
 {
-    return run_tests<libdap::ArrayTest>(argc, argv) ? 0: 1;
+    return run_tests<libdap::BigArrayTest>(argc, argv) ? 0: 1;
 }

--- a/unit-tests/BigArrayTest.cc
+++ b/unit-tests/BigArrayTest.cc
@@ -1,0 +1,395 @@
+// -*- mode: c++; c-basic-offset:4 -*-
+
+// This file is part of libdap, A C++ implementation of the OPeNDAP Data
+// Access Protocol.
+
+// Copyright (c) 2005,2018 OPeNDAP, Inc.
+// Author: James Gallagher <jgallagher@opendap.org>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+// You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+
+#include <cppunit/TextTestRunner.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <cstring>
+#include <string>
+
+#include <unistd.h>
+
+#include "GNURegex.h"
+
+#include "Array.h"
+#include "Int16.h"
+#include "Int64.h"
+#include "Float32.h"
+#include "Str.h"
+#include "D4Enum.h"
+#include "Structure.h"
+#include "D4Dimensions.h"
+
+#include "run_tests_cppunit.h"
+#include "test_config.h"
+
+using namespace CppUnit;
+using namespace std;
+
+namespace libdap {
+
+class ArrayTest: public TestFixture {
+private:
+    Array *d_cardinal = nullptr;
+    Array *d_string = nullptr;
+    Array *d_structure = nullptr;
+    Array *d_card_dap4 = nullptr;
+
+    Int16 *d_int16 = nullptr;
+    Str *d_str = nullptr;
+    Structure *d_struct = nullptr;
+
+    string svalues[4] = {"0 String", "1 String", "2 String", "3 String" };
+    
+public:
+    ArrayTest() = default;
+
+    ~ArrayTest() = default;
+
+    void setUp()
+    {
+        d_int16 = new Int16("Int16");
+        DBG(cerr << "d_int16: " << d_int16 << endl);
+        d_cardinal = new Array("Array_of_Int16", d_int16);
+        d_cardinal->append_dim(4, "dimension");
+        dods_int16 buffer[4] = { 0, 1, 2, 3 };
+        d_cardinal->val2buf(buffer);
+
+        // Added to test if Arrays with DAP4 protos will have is_dap4() == true. jhrg 7/27/22
+        Int64 i64("");
+        d_card_dap4 = new Array("Array_of_Int64", &i64);
+        d_card_dap4->append_dim(4, "dimension");
+        dods_int64 buffer64[4] = { 0, 1, 2, 3 };
+        d_card_dap4->val2buf(buffer64);
+
+
+        d_str = new Str("Str");
+        d_string = new Array("Array_of_String", d_str);
+        d_string->append_dim(4, "dimension");
+        string sbuffer[4] = { "0 String", "1 String", "2 String", "3 String" };
+        d_string->val2buf(sbuffer);
+
+        d_struct = new Structure("Structure");
+        d_struct->add_var(d_int16);
+        d_structure = new Array("Array_of_Strctures", d_struct);
+        d_structure->append_dim(4, "dimension");
+        ostringstream oss;
+        for (int i = 0; i < 4; ++i) {
+            oss.str("");
+            oss << "field" << i;
+            Int16 *n = new Int16(oss.str());
+            DBG(cerr << "n " << i << ": " << n << endl);
+            oss.str("");
+            oss << "element" << i;
+            Structure *s = new Structure(oss.str());
+            s->add_var(n);
+            d_structure->set_vec(i, s);
+            delete n;
+            n = 0;
+            delete s;
+            s = 0;
+        }
+
+        delete d_int16;
+        d_int16 = 0;
+        delete d_str;
+        d_str = 0;
+        delete d_struct;
+        d_struct = 0;
+    }
+
+    void tearDown()
+    {
+        delete d_cardinal;
+        delete d_string;
+        delete d_structure;
+    }
+
+    bool re_match(Regex &r, const char *s)
+    {
+        int match_position = r.match(s, strlen(s));
+        DBG(cerr << "match position: " << match_position
+            << " string length: " << (int)strlen(s) << endl);
+        return match_position == (int) strlen(s);
+    }
+
+    CPPUNIT_TEST_SUITE (ArrayTest);
+
+    CPPUNIT_TEST (cons_test);
+    CPPUNIT_TEST (test_is_dap4_1);
+    CPPUNIT_TEST (test_is_dap4_2);
+    CPPUNIT_TEST (test_is_dap4_3);
+    CPPUNIT_TEST (test_is_dap4_4);
+    CPPUNIT_TEST (assignment_test_1);
+    CPPUNIT_TEST (assignment_test_2);
+    CPPUNIT_TEST (assignment_test_3);
+    CPPUNIT_TEST (prepend_dim_test);
+    CPPUNIT_TEST (prepend_dim_2_test);
+    CPPUNIT_TEST (clear_dims_test);
+    CPPUNIT_TEST (error_handling_test);
+    CPPUNIT_TEST (error_handling_2_test);
+    CPPUNIT_TEST (duplicate_cardinal_test);
+    CPPUNIT_TEST (duplicate_string_test);
+    CPPUNIT_TEST (duplicate_structure_test);
+
+    CPPUNIT_TEST_SUITE_END();
+
+    void cons_test()
+    {
+        Array a1 = Array("a", "b", d_int16, true);
+        CPPUNIT_ASSERT(a1.name() == "a");
+    }
+
+    void test_is_dap4_1() {
+        DBG(d_card_dap4->dump(cerr));
+        CPPUNIT_ASSERT_MESSAGE("This Array should register as DAP4", d_card_dap4->is_dap4());
+    }
+
+    void test_is_dap4_2() {
+        DBG(d_cardinal->dump(cerr));
+        CPPUNIT_ASSERT_MESSAGE("This Array should not register as DAP4", !d_cardinal->is_dap4());
+    }
+
+    void test_is_dap4_3() {
+        // An array Enum is always DAP4, even when the underlying type of the enum is not
+        D4Enum enum16("", dods_int16_c);
+        unique_ptr<Array> enum_array_dap4(new Array("Array_of_Enum", &enum16));
+        enum_array_dap4->append_dim(4, "dimension");
+        dods_int16 buffer16[4] = { 0, 1, 2, 3 };
+        enum_array_dap4->val2buf(buffer16);
+
+        DBG(enum_array_dap4->dump(cerr));
+        CPPUNIT_ASSERT_MESSAGE("This Array should register as DAP4", enum_array_dap4->is_dap4());
+    }
+
+    void test_is_dap4_4() {
+        D4Enum enum64("", dods_int64_c);
+        unique_ptr<Array> enum_array_dap4(new Array("Array_of_Enum", &enum64));
+        enum_array_dap4->append_dim(4, "dimension");
+        dods_int64 buffer64[4] = { 0, 1, 2, 3 };
+        enum_array_dap4->val2buf(buffer64);
+
+        DBG(enum_array_dap4->dump(cerr));
+        CPPUNIT_ASSERT_MESSAGE("This Array should register as DAP4", enum_array_dap4->is_dap4());
+    }
+
+    void assignment_test_1()
+    {
+        // Are fields from the object copied by the assignment
+        Array a1 = Array("a", d_int16);
+        a1.append_dim(17, "bob");
+        CPPUNIT_ASSERT(a1.dimension_size(a1.dim_begin()) == 17);
+        a1 = *d_cardinal;
+        CPPUNIT_ASSERT(a1.dimension_size(a1.dim_begin()) == 4);
+    }
+
+    void assignment_test_2()
+    {
+        // Self-assignment; are objects changed by the assignment?
+        Array a1 = Array("a", d_int16);
+        Array *before = &a1;
+        a1 = a1;
+        Array *after = &a1;
+        CPPUNIT_ASSERT_MESSAGE("The pointers should be the same", before == after);
+    }
+
+    // This tests that the assignment operator defined in Array correctly copies
+    // information held in a parent class (Vector). jhrg 2/9/22
+    void assignment_test_3()
+    {
+        // Array copies the proto pointer and manages the storage
+#if 0       
+        unique_ptr<Float32> f32(new Float32("float_proto"));
+        Array a1 = Array("a", f32.get());
+#endif
+        auto f32_ptr = new Float32("float_proto");
+        Array a1 = Array("a", f32_ptr);
+	delete f32_ptr;
+	
+        CPPUNIT_ASSERT_MESSAGE("The type of a1.var() should be dods_float32", a1.var()->type() == dods_float32_c);
+        a1 = *d_cardinal;
+        CPPUNIT_ASSERT_MESSAGE("The type of a1.var() should now be dods_int16_c", a1.var()->type() == dods_int16_c);
+    }
+
+    void prepend_dim_test()
+    {
+        Array a1 = Array("a", d_int16);
+        Array::Dim_iter i = a1.dim_begin();
+        CPPUNIT_ASSERT(a1.dimension_size(i) == 0);
+        a1.prepend_dim(2, "dim_a");
+        i = a1.dim_begin();
+        CPPUNIT_ASSERT(a1.dimension_size(i) == 2);
+        a1.prepend_dim(3, "dim_b");
+    }
+
+    void prepend_dim_2_test()
+    {
+        Array a1 = Array("a", d_int16);
+        string expected_name[2] = {"dim_b", "myDim"};
+        int j = 0;
+        D4Dimensions *dims = new D4Dimensions();
+        D4Dimension *d = new D4Dimension("dim_b", 2, dims);
+        a1.prepend_dim(2, "dim_a");
+        a1.prepend_dim(d);
+        a1.rename_dim("dim_a", "myDim");
+        for (Array::Dim_iter i = a1.dim_begin(); i != a1.dim_end(); i++, j++) {
+            CPPUNIT_ASSERT(a1.dimension_name(i) == expected_name[j]);
+        }
+        delete dims;
+        delete d;
+    }
+
+    void clear_dims_test()
+    {
+        Array a1 = Array("a", d_int16);
+        a1.prepend_dim(2, "dim_a");
+        a1.prepend_dim(3, "dim_b");
+        a1.clear_all_dims();
+        Array::Dim_iter i = a1.dim_begin();
+        CPPUNIT_ASSERT(a1.dimension_size(i) == 0);
+    }
+
+    void error_handling_test()
+    {
+        Array a1 = Array("a", d_int16);
+        Array::Dim_iter i = a1.dim_begin();
+        string msg;
+        CPPUNIT_ASSERT_THROW(a1.dimension_name(i), InternalErr);
+        CPPUNIT_ASSERT(!a1.check_semantics(msg));
+    }
+
+    void error_handling_2_test()
+    {
+        Array a1 = Array("a", d_int16);
+        a1.append_dim(2, "dim_a");
+        Array::Dim_iter i = a1.dim_begin();
+        CPPUNIT_ASSERT(a1.dimension_size(i) == 2);
+        CPPUNIT_ASSERT_THROW(a1.add_constraint(i, 2, 1, 1), Error);
+        CPPUNIT_ASSERT_THROW(a1.add_constraint(i, 0, 1, 2), Error);
+        CPPUNIT_ASSERT_THROW(a1.add_constraint(i, 0, 3, 1), Error);
+    }
+
+    void duplicate_structure_test()
+    {
+        Array::Dim_iter i = d_structure->dim_begin();
+        CPPUNIT_ASSERT(d_structure->dimension_size(i) == 4);
+#ifdef DODS_DEBUG
+        for (int i = 0; i < 4; ++i) {
+            Structure *s = dynamic_cast<Structure*>(d_structure->var(i));
+            DBG(cerr << "s: " << s << endl);
+            if (s)
+            s->print_decl(cerr);
+        }
+#endif
+
+        Array *a = new Array(*d_structure);
+        // a = *d_structure; I test operator= in duplicate_cardinal_test().
+        i = a->dim_begin();
+        CPPUNIT_ASSERT(a->dimension_size(i) == 4);
+        for (int i = 0; i < 4; ++i) {
+            // The point of this test is to ensure that the const ctor
+            // performs a deep copy; first test to make sure the pointers
+            // to BaseType instnaces are different in the two objects.
+            Structure *src = dynamic_cast<Structure*>(d_structure->var(i));
+            Structure *dest = dynamic_cast<Structure*>(a->var(i));
+            CPPUNIT_ASSERT(src != dest);
+
+            // However, for the deep copy to be correct, the two arrays must
+            // have equivalent elements. We know there's only one field...
+            CPPUNIT_ASSERT(src->type() == dods_structure_c && dest->type() == dods_structure_c);
+            Constructor::Vars_iter s = src->var_begin();
+            Constructor::Vars_iter d = dest->var_begin();
+            CPPUNIT_ASSERT((*s)->type() == dods_int16_c && (*d)->type() == dods_int16_c);
+            CPPUNIT_ASSERT((*s)->name() == (*d)->name());
+        }
+        delete a;
+        a = 0;
+    }
+
+    void duplicate_string_test()
+    {
+        Array::Dim_iter i = d_string->dim_begin();
+        CPPUNIT_ASSERT(d_string->dimension_size(i) == 4);
+        string *s = new string[4];
+        d_string->buf2val((void**) &s);
+        for (int i = 0; i < 4; ++i) {
+            CPPUNIT_ASSERT(s[i] == svalues[i]);
+            DBG(cerr << "s[" << i << "]: " << s[i] << endl);
+        }
+
+        Array a = *d_string;
+        i = a.dim_begin();
+        CPPUNIT_ASSERT(a.dimension_size(i) == 4);
+
+        string *s2 = new string[4];
+        d_string->buf2val((void**) &s2);
+        for (int i = 0; i < 4; ++i) {
+            CPPUNIT_ASSERT(s2[i] == svalues[i]);
+            DBG(cerr << "s2[" << i << "]: " << s2[i] << endl);
+        }
+
+        delete[] s;
+        s = 0;
+        delete[] s2;
+        s2 = 0;
+    }
+
+    void duplicate_cardinal_test()
+    {
+        Array::Dim_iter i = d_cardinal->dim_begin();
+        CPPUNIT_ASSERT(d_cardinal->dimension_size(i) == 4);
+        dods_int16 *b = new dods_int16[4];
+        d_cardinal->buf2val((void**) &b);
+        for (int i = 0; i < 4; ++i) {
+            CPPUNIT_ASSERT(b[i] == i);
+            DBG(cerr << "b[" << i << "]: " << b[i] << endl);
+        }
+        delete[] b;
+        b = 0;
+
+        Array a = *d_cardinal;
+        i = a.dim_begin();
+        CPPUNIT_ASSERT(a.dimension_size(i) == 4);
+
+        dods_int16 *b2 = new dods_int16[4];
+        d_cardinal->buf2val((void**) &b2);
+        for (int i = 0; i < 4; ++i) {
+            CPPUNIT_ASSERT(b2[i] == i);
+            DBG(cerr << "b2[" << i << "]: " << b2[i] << endl);
+        }
+        delete[] b2;
+        b2 = 0;
+    }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION (ArrayTest);
+
+} // namespace libdap
+
+int main(int argc, char *argv[])
+{
+    return run_tests<libdap::ArrayTest>(argc, argv) ? 0: 1;
+}

--- a/unit-tests/Makefile.am
+++ b/unit-tests/Makefile.am
@@ -109,6 +109,13 @@ check-local:
 	@echo ""
 endif
 
+# If cppunit exists and big array test option are chosen, turn on BigArrayTest.
+if CPPUNIT
+if USE_BA
+UNIT_TESTS +=BigArrayTest
+endif
+endif
+
 # making these link statically makes them easier to debug and to use
 # with OSX's leaks tool. It also seems to force the linker to use the
 # locally built copy of the library and not the installed copy.
@@ -244,4 +251,7 @@ DmrToDap2Test_SOURCES = DmrToDap2Test.cc $(TEST_SRC)
 D4FilterClauseTest_SOURCES = D4FilterClauseTest.cc
 
 D4SequenceTest_SOURCES = D4SequenceTest.cc $(TEST_SRC)
+
+BigArrayTest_SOURCES = BigArrayTest.cc $(TEST_SRC)
+
 D4SequenceTest_LDADD = ../tests/libtest-types.a ../libdap.la $(AM_LDADD)


### PR DESCRIPTION
1. BigArrayTest.cc is added. val2buf, buf2val, set_value and value() are tested with 5GB array.
2. configure.ac and unit-test/Makefile.am are modified to enable the BigArrayTest as an option.
3. Test BigArrayTest use ./configure --enable-batest
4. Currently there are bugs inside libdap4, the big array tests failed. Another ticket will be created for fixing the libdap. 