### PR TITLE
Add missing cstdint include for uint32_t

### DIFF
--- a/Constructor.cc
+++ b/Constructor.cc
@@ -31,6 +31,7 @@
 
 #include "config.h"
 
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <algorithm>


### PR DESCRIPTION
Builds started to fail in fedora rawhide with gcc 13 with:
```
In file included from Constructor.cc:38:
crc.h:9:14: error: 'uint32_t' does not name a type
    9 | static const uint32_t kCrc32Table[256] = {
      |              ^~~~~~~~
crc.h:1:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
  +++ |+#include <cstdint>
    1 | /*
```
This fixes it.