### PR TITLE
add missing include

### DIFF
--- a/Vector.cc
+++ b/Vector.cc
@@ -37,6 +37,7 @@
 
 #include <cstring>
 #include <cassert>
+#include <cstdint>
 
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
With GCC 13 the <cstdint> header isn't included thru other headers any more, thus include it explictly. Otherwise uint8_t or uint32_t type remain undefined in Vector.cc.

Fixes: https://github.com/OPENDAP/libdap4/issues/226