### PR TITLE
configure: avoid broken bashisms

### DIFF
--- a/conf/ox_rhel8_tirpc.m4
+++ b/conf/ox_rhel8_tirpc.m4
@@ -27,7 +27,7 @@ AS_IF([test -f /etc/redhat-release && grep -q '8\.' /etc/redhat-release],
     dnl if this is RHEL8, then we need the tirpc library on CPPFLAGS and LDFLAGS
     [
         AC_MSG_NOTICE([Found a RHEL 8 or equivalent system...])
-        AS_IF([grep -q -v tirpc <<< $CPPFLAGS || grep -q -v tirpc <<< $LDFLAGS],
+        AS_IF([echo $CPPFLAGS | grep -q -v tirpc || echo $LDFLAGS | grep -q -v tirpc],
         dnl if either CPPFLAGS or LDFLAGS lack 'tirpc', error
         [
             AC_MSG_ERROR([Libdap4 on Redhat Linux 8 requires the tirpc library be included on CPPFLAGS and LDFLAGS])
@@ -39,4 +39,3 @@ AS_IF([test -f /etc/redhat-release && grep -q '8\.' /etc/redhat-release],
         AC_MSG_NOTICE([Not a RHEL 8 or equivalent system])
     ])
 ])
-


### PR DESCRIPTION
configure scripts are run with /bin/sh, and must use /bin/sh syntax rather than bashisms.

<<< is a bash specific syntax. Refrain from using it. Instead simply echo into a pipe, which does the same thing.

Fixes the following error:

```
checking for XML2... yes
checking for libxml2... yes; used pkg-config
./configure: 31971: Syntax error: redirection unexpected
```