### PR TITLE
HYRAX-1497, Provide an option to use UTF-8 encoding …

### DIFF
--- a/DMR.h
+++ b/DMR.h
@@ -90,6 +90,7 @@ private:
     /// A global flag to indicate if we need to use direct IO
     bool global_dio_flag = false;
 
+    bool utf8_xml_encoding = false;
     friend class DMRTest;
     friend class MockDMR;
 
@@ -228,6 +229,10 @@ public:
     // The following methods are for direct IO optimization.
     bool get_global_dio_flag() const { return global_dio_flag; }
     void set_global_dio_flag(bool dio_flag_value = true) { global_dio_flag = dio_flag_value; }
+
+    // The following methods are for utf8_encoding.
+    bool get_utf8_xml_encoding() const { return utf8_xml_encoding; }
+    void set_utf8_xml_encoding(bool encoding_value = true) { utf8_xml_encoding = encoding_value; }
 };
 
 } // namespace libdap

--- a/XMLWriter.cc
+++ b/XMLWriter.cc
@@ -38,7 +38,7 @@
 
 // TODO - Bite the bullet and make the encoding UTF-8 as required by dap4. This will break a lot of tests but the
 // baselines could be amended using  a bash script and sed.
-//const char *ENCODING = "ISO-8859-1";
+
 const int XML_BUF_SIZE = 2000000;
 
 using namespace libdap;
@@ -70,8 +70,6 @@ XMLWriter::XMLWriter(const string &pad, const string &ENCODING) {
         d_started = true;
         d_ended = false;
 
-        xpad = pad;
-
         /* Start the document with the xml default for the version,
          * encoding ISO 8859-1 and the default for the standalone
          * declaration. MY_ENCODING defined at top of this file*/
@@ -81,52 +79,7 @@ XMLWriter::XMLWriter(const string &pad, const string &ENCODING) {
         m_cleanup();
         throw;
     }
-
 }
-
-void XMLWriter::XMLWriter_utf8_encoding() {
-
-#if 0
-    if (d_writer) {
-        xmlFreeTextWriter(d_writer); // This frees both d_writer and d_doc_buf
-        d_writer = 0;
-    }
-#endif
-
-    m_cleanup();
-
-    try {
-    /* Create a new XmlWriter for memory, with no compression.
-    * Remark: there is no compression for this kind of xmlTextWriter */
-     if (!(d_doc_buf = xmlBufferCreateSize(XML_BUF_SIZE)))
-            throw InternalErr(__FILE__, __LINE__, "Error allocating the xml buffer");
-
-        xmlBufferSetAllocationScheme(d_doc_buf, XML_BUFFER_ALLOC_DOUBLEIT);
-
-    if (!(d_writer = xmlNewTextWriterMemory(d_doc_buf, 0)))
-            throw InternalErr(__FILE__, __LINE__, "Error allocating memory for xml writer");
-
-        if (xmlTextWriterSetIndent(d_writer, xpad.length()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Error starting indentation for response document ");
-
-        if (xmlTextWriterSetIndentString(d_writer, (const xmlChar *)xpad.c_str()) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Error setting indentation for response document ");
-
-        d_started = true;
-        d_ended = false;
-
-        /* Start the document with the xml default for the version,
-         * encoding ISO 8859-1 and the default for the standalone
-         * declaration. MY_ENCODING defined at top of this file*/
-        const char* encoding ="UTF-8";
-        if (xmlTextWriterStartDocument(d_writer, NULL, encoding, NULL) < 0)
-            throw InternalErr(__FILE__, __LINE__, "Error starting xml response document");
-    } catch (InternalErr &e) {
-        m_cleanup();
-        throw;
-    }
-}
-
 
 XMLWriter::~XMLWriter() { m_cleanup(); }
 

--- a/XMLWriter.cc
+++ b/XMLWriter.cc
@@ -38,12 +38,12 @@
 
 // TODO - Bite the bullet and make the encoding UTF-8 as required by dap4. This will break a lot of tests but the
 // baselines could be amended using  a bash script and sed.
-const char *ENCODING = "ISO-8859-1";
+//const char *ENCODING = "ISO-8859-1";
 const int XML_BUF_SIZE = 2000000;
 
 using namespace libdap;
 
-XMLWriter::XMLWriter(const string &pad) {
+XMLWriter::XMLWriter(const string &pad, const string &ENCODING) {
     // LEAK The LIBXML_TEST_VERSION macro leaks 40 bytes according to valgrind
     // on centos7. jhrg 6/19/19
     // LIBXML_TEST_VERSION;
@@ -70,16 +70,63 @@ XMLWriter::XMLWriter(const string &pad) {
         d_started = true;
         d_ended = false;
 
+        xpad = pad;
+
         /* Start the document with the xml default for the version,
          * encoding ISO 8859-1 and the default for the standalone
          * declaration. MY_ENCODING defined at top of this file*/
-        if (xmlTextWriterStartDocument(d_writer, NULL, ENCODING, NULL) < 0)
+        if (xmlTextWriterStartDocument(d_writer, NULL, ENCODING.c_str(), NULL) < 0)
+            throw InternalErr(__FILE__, __LINE__, "Error starting xml response document");
+    } catch (InternalErr &e) {
+        m_cleanup();
+        throw;
+    }
+
+}
+
+void XMLWriter::XMLWriter_utf8_encoding() {
+
+#if 0
+    if (d_writer) {
+        xmlFreeTextWriter(d_writer); // This frees both d_writer and d_doc_buf
+        d_writer = 0;
+    }
+#endif
+
+    m_cleanup();
+
+    try {
+    /* Create a new XmlWriter for memory, with no compression.
+    * Remark: there is no compression for this kind of xmlTextWriter */
+     if (!(d_doc_buf = xmlBufferCreateSize(XML_BUF_SIZE)))
+            throw InternalErr(__FILE__, __LINE__, "Error allocating the xml buffer");
+
+        xmlBufferSetAllocationScheme(d_doc_buf, XML_BUFFER_ALLOC_DOUBLEIT);
+
+    if (!(d_writer = xmlNewTextWriterMemory(d_doc_buf, 0)))
+            throw InternalErr(__FILE__, __LINE__, "Error allocating memory for xml writer");
+
+        if (xmlTextWriterSetIndent(d_writer, xpad.length()) < 0)
+            throw InternalErr(__FILE__, __LINE__, "Error starting indentation for response document ");
+
+        if (xmlTextWriterSetIndentString(d_writer, (const xmlChar *)xpad.c_str()) < 0)
+            throw InternalErr(__FILE__, __LINE__, "Error setting indentation for response document ");
+
+        d_started = true;
+        d_ended = false;
+
+        /* Start the document with the xml default for the version,
+         * encoding ISO 8859-1 and the default for the standalone
+         * declaration. MY_ENCODING defined at top of this file*/
+        const char* encoding ="UTF-8";
+        if (xmlTextWriterStartDocument(d_writer, NULL, encoding, NULL) < 0)
             throw InternalErr(__FILE__, __LINE__, "Error starting xml response document");
     } catch (InternalErr &e) {
         m_cleanup();
         throw;
     }
 }
+
 
 XMLWriter::~XMLWriter() { m_cleanup(); }
 

--- a/XMLWriter.h
+++ b/XMLWriter.h
@@ -44,16 +44,14 @@ private:
     bool d_started;
     bool d_ended;
 
-    std::string xpad;
     std::string d_doc;
 
     void m_cleanup();
 
 public:
-    XMLWriter(const std::string &pad = "    ", const std::string &ENCODING="ISO-8859-1");
+    XMLWriter(const std::string &pad = "    ", const std::string &ENCODING = "ISO-8859-1");
     virtual ~XMLWriter();
 
-    void XMLWriter_utf8_encoding();
     xmlTextWriterPtr get_writer() const { return d_writer; }
     const char *get_doc();
     unsigned int get_doc_size();

--- a/XMLWriter.h
+++ b/XMLWriter.h
@@ -44,14 +44,16 @@ private:
     bool d_started;
     bool d_ended;
 
+    std::string xpad;
     std::string d_doc;
 
     void m_cleanup();
 
 public:
-    XMLWriter(const std::string &pad = "    ");
+    XMLWriter(const std::string &pad = "    ", const std::string &ENCODING="ISO-8859-1");
     virtual ~XMLWriter();
 
+    void XMLWriter_utf8_encoding();
     xmlTextWriterPtr get_writer() const { return d_writer; }
     const char *get_doc();
     unsigned int get_doc_size();


### PR DESCRIPTION
…for the unescaped Unicode characters in DAP4.

Tested BES at MacOS 14 and 13, CentOS 7 and Ubuntu 24.04.