### PR TITLE
Switch to the Meyers singleton pattern for HTTPCache

### DIFF
--- a/http_dap/HTTPCache.cc
+++ b/http_dap/HTTPCache.cc
@@ -64,6 +64,7 @@ const string DIR_SEPARATOR_CHAR{"/"};
 
 namespace libdap {
 
+#if 0
 std::unique_ptr<HTTPCache> HTTPCache::d_instance = nullptr;
 
 /** Get a pointer to the HTTP 1.1 compliant cache. If not already
@@ -98,6 +99,7 @@ HTTPCache *HTTPCache::instance(const string &cache_root) {
 
     return d_instance.get();
 }
+#endif
 
 /** Create an instance of the HTTP 1.1 compliant cache. This initializes the
     both the cache root and the path to the index file. It then reads the

--- a/http_dap/Makefile.am
+++ b/http_dap/Makefile.am
@@ -28,7 +28,7 @@ AM_LDFLAGS =
 include $(top_srcdir)/coverage.mk
 
 noinst_LTLIBRARIES = libhttp_dap.la
-pkginclude_HEADERS = HTTPConnect.h HTTPCache.h HTTPCacheDisconnectedMode.h
+pkginclude_HEADERS = HTTPConnect.h HTTPCache.h HTTPCacheTable.h HTTPCacheDisconnectedMode.h
 
 BUILT_SOURCES =
 


### PR DESCRIPTION
Switch to the Meyers singleton pattern for HTTPCache

A fix for the BES dapreader test failures with the new libdap.