### PR TITLE
jhrg/HYRAX-1796-cmake-install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ set_directory_properties(PROPERTIES
 )
 
 # Define libraries
-add_library(parsers STATIC ${GENERATED_PARSER_SRC})
+add_library(parsers OBJECT ${GENERATED_PARSER_SRC})
 target_include_directories(parsers PRIVATE ${LIBXML2_INCLUDE_DIR})
 # target_include_directories(parsers PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(parsers PRIVATE ${LIBXML2_LIBRARIES})
@@ -264,13 +264,19 @@ endif()
 set_target_properties(parsers PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(dap SHARED ${DAP_SRC} ${GNU_SRC} ${DAP4_ONLY_SRC})
+target_sources(dap PRIVATE
+        $<TARGET_OBJECTS:parsers>
+        $<TARGET_OBJECTS:d4_ce_parser>
+        $<TARGET_OBJECTS:d4_function_parser>
+)
 target_include_directories(dap PRIVATE ${LIBXML2_INCLUDE_DIR})
 # target_include_directories(dap PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 if(TIRPC_FOUND)
     target_include_directories(dap PRIVATE ${TIRPC_INCLUDE_DIRS})
     target_link_libraries(dap PRIVATE ${TIRPC_LIBRARIES})
 endif()
-target_link_libraries(dap PRIVATE parsers ${LIBXML2_LIBRARIES} Threads::Threads)
+# target_link_libraries(dap PRIVATE parsers d4_ce_parser d4_function_parser)
+target_link_libraries(dap PRIVATE ${LIBXML2_LIBRARIES} Threads::Threads)
 set_target_properties(dap PROPERTIES VERSION ${LIBDAP_VERSION}) # SOVERSION ${LIBDAP_SO_VERSION})
 
 message(STATUS "INCLUDE PATHS for dap:")
@@ -278,6 +284,9 @@ get_target_property(DAP_INCLUDES dap INCLUDE_DIRECTORIES)
 message(STATUS "  ${DAP_INCLUDES}")
 
 add_library(dapclient SHARED ${CLIENT_SRC})
+target_sources(dapclient PRIVATE
+        $<TARGET_OBJECTS:http_dap>
+)
 target_include_directories(dapclient PRIVATE ${CURL_INCLUDE_DIRS})
 target_include_directories(dapclient PRIVATE ${LIBXML2_INCLUDE_DIR})
 # target_include_directories(dapclient PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
@@ -285,7 +294,8 @@ if(TIRPC_FOUND)
     target_include_directories(dapclient PRIVATE ${TIRPC_INCLUDE_DIRS})
     target_link_libraries(dapclient PRIVATE ${TIRPC_LIBRARIES})
 endif()
-target_link_libraries(dapclient PRIVATE dap http_dap ${CURL_LIBRARIES} Threads::Threads)
+target_link_libraries(dapclient PRIVATE dap)
+target_link_libraries(dapclient PRIVATE ${CURL_LIBRARIES} Threads::Threads)
 
 set_target_properties(dapclient PROPERTIES VERSION ${LIBDAP_VERSION}) # SOVERSION ${CLIENTLIB_SO_VERSION})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,14 @@ set(LIBDAP_VERSION "3.21.1")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Tells the linker to embed the final install path
+# (e.g., /usr/local/lib or /custom/prefix/lib) which is
+# generally less likely to break for code that does not
+# use cmake. Not sure how this will work on platforms
+# that use ...lib64. 6/27/25 jhrg
+set(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+
 # Look for 'find' macros in the 'cmake' dir. jhrg 6/18/25
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,35 @@ configure_file(
         "${CMAKE_CURRENT_BINARY_DIR}/xdr-datatypes.h"
 )
 
+# This is local to this project. 6/25/25/ jhrg
+include(cmake/GenerateCompilerFlags.cmake)
+
+generate_pkg_config_flags(CURL CURL_INCLUDE_DIRS CURL_LIBRARIES
+        CURL_PKG_CFLAGS CURL_PKG_LIBS)
+
+generate_pkg_config_flags(LibXml2 LIBXML2_INCLUDE_DIR LIBXML2_LIBRARIES
+        XML2_PKG_CFLAGS XML2_PKG_LIBS)
+
+generate_pkg_config_flags(TIRPC TIRPC_INCLUDE_DIRS TIRPC_LIBRARIES
+        TIRPC_PKG_CFLAGS TIRPC_PKG_LIBS)
+
+configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/dap-config.in.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/dap-config"
+        @ONLY
+)
+
+install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/dap-config"
+        DESTINATION bin)
+
+configure_file(
+        ${CMAKE_SOURCE_DIR}/libdap.pc.in
+        ${CMAKE_BINARY_DIR}/libdap.pc
+        @ONLY
+)
+
+install(FILES ${CMAKE_BINARY_DIR}/libdap.pc DESTINATION lib/pkgconfig)
+
 ### I am not sure we need this anymore - copied from the autotools build.
 ### This is very old, we never build on Solaris anymore. jhrg 6/10/25
 # Check if we're on Solaris (typically passed in by the toolchain)
@@ -341,3 +370,44 @@ set_directory_properties(PROPERTIES
         ADDITIONAL_MAKE_CLEAN_FILES "*.gcda;*.gcno;*.gcov"
 )
 
+# This supports the libdap4Config.cmake file. 6/25/25 jhrg
+# With this, people can use:
+#find_package(libdap4 CONFIG REQUIRED)
+#target_link_libraries(mytool PRIVATE libdap4::dapclient)
+#
+# Make sure the install prefix is in CMAKE_PREFIX_PATH or CMAKE_INSTALL_PREFIX/lib/cmake/libdap4
+
+# Set install location for config files
+set(LIBDAP4_CONFIG_INSTALL_DIR lib/cmake/libdap4)
+
+# Export only public-facing targets
+install(TARGETS dap dapclient dapserver
+        EXPORT libdap4Targets
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include/libdap)
+
+# Install the generated Config.cmake and export file
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+        "${CMAKE_SOURCE_DIR}/cmake/libdap4Config.cmake.in"
+        "${CMAKE_BINARY_DIR}/libdap4Config.cmake"
+        INSTALL_DESTINATION ${LIBDAP4_CONFIG_INSTALL_DIR}
+)
+
+write_basic_package_version_file(
+        "${CMAKE_BINARY_DIR}/libdap4ConfigVersion.cmake"
+        VERSION ${LIBDAP_VERSION}
+        COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+        "${CMAKE_BINARY_DIR}/libdap4Config.cmake"
+        "${CMAKE_BINARY_DIR}/libdap4ConfigVersion.cmake"
+        DESTINATION ${LIBDAP4_CONFIG_INSTALL_DIR}
+)
+
+install(EXPORT libdap4Targets
+        NAMESPACE libdap4::
+        DESTINATION ${LIBDAP4_CONFIG_INSTALL_DIR})

--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -15,6 +15,7 @@ check_include_files("sys/stat.h" HAVE_SYS_STAT_H)
 check_include_files("sys/types.h;sys/stat.h" HAVE_SYS_TYPES_H_AND_SYS_STAT_H)
 check_include_files("string.h" HAVE_STRING_H)
 check_include_files("stdlib.h" HAVE_STDLIB_H)
+check_include_files("regex.h" HAVE_REGEX_H)
 
 # Library headers
 check_include_files("libxml/xmlwriter.h" HAVE_LIBXML2)

--- a/GNU/GNURegex.cc
+++ b/GNU/GNURegex.cc
@@ -23,8 +23,6 @@
 //
 // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
 
-// #define DODS_DEBUG
-
 #include "config.h"
 
 #include <iostream>

--- a/GNU/GNURegex.h
+++ b/GNU/GNURegex.h
@@ -26,6 +26,8 @@
 #ifndef _Regex_h
 #define _Regex_h 1
 
+#include "config.h"
+
 #ifndef USE_CPP_11_REGEX
 #define USE_CPP_11_REGEX 0
 #endif

--- a/RValue.h
+++ b/RValue.h
@@ -32,7 +32,7 @@
 #ifndef _rvalue_h
 #define _rvalue_h
 
-#include <dods-datatypes.h>
+#include "dods-datatypes.h"
 
 #include "expr.h"
 

--- a/cmake/GenerateCompilerFlags.cmake
+++ b/cmake/GenerateCompilerFlags.cmake
@@ -1,0 +1,45 @@
+
+# These cmake functions take variables set using find_pacakge, etc., and
+# reformat them so they can be easily used by the dap-config script and
+# pkg-config *.pc scripts. 6/25/25 jhrg
+
+function(generate_include_flags input_list_var output_var)
+	set(result "")
+	foreach(path IN LISTS ${input_list_var})
+		list(APPEND result "-I${path}")
+	endforeach()
+	list(REMOVE_DUPLICATES result)
+	string(JOIN " " joined_result ${result})
+	set(${output_var} "${joined_result}" PARENT_SCOPE)
+endfunction()
+
+function(generate_link_flags input_libs_var ldflags_out_var ldlibs_out_var)
+	set(ldflags "")
+	set(ldlibs "")
+
+	foreach(lib IN LISTS ${input_libs_var})
+		get_filename_component(lib_dir "${lib}" DIRECTORY)
+		get_filename_component(lib_name "${lib}" NAME_WE)
+		string(REPLACE "lib" "" lib_stripped "${lib_name}")
+
+		list(APPEND ldflags "-L${lib_dir}")
+		list(APPEND ldlibs "-l${lib_stripped}")
+	endforeach()
+
+	list(REMOVE_DUPLICATES ldflags)
+	list(REMOVE_DUPLICATES ldlibs)
+
+	string(JOIN " " joined_ldflags ${ldflags})
+	string(JOIN " " joined_ldlibs ${ldlibs})
+
+	set(${ldflags_out_var} "${joined_ldflags}" PARENT_SCOPE)
+	set(${ldlibs_out_var} "${joined_ldlibs}" PARENT_SCOPE)
+endfunction()
+
+function(generate_pkg_config_flags prefix incs libs out_cflags out_libs)
+	generate_include_flags(${incs} _incs)
+	generate_link_flags(${libs} _ldflags _ldlibs)
+
+	set(${out_cflags} "${_incs}" PARENT_SCOPE)
+	set(${out_libs} "${_ldflags} ${_ldlibs}" PARENT_SCOPE)
+endfunction()

--- a/cmake/libdap4Config.cmake.in
+++ b/cmake/libdap4Config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Optional: include dependencies if installed system-wide
+find_dependency(Threads)
+find_dependency(CURL)
+find_dependency(LibXml2)
+
+include("${CMAKE_CURRENT_LIST_DIR}/libdap4Targets.cmake")

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -2,8 +2,8 @@
 // Created by James Gallagher on 6/8/25.
 //
 
-#ifndef S_WORKS_CONFIG_DAP_H
-#define S_WORKS_CONFIG_DAP_H
+#ifndef CONFIG_H
+#define CONFIG_H
 
 /* Libraries */
 #cmakedefine HAVE_LIBXML2
@@ -27,6 +27,7 @@
 #cmakedefine HAVE_SYS_TYPES_H_AND_SYS_STAT_H
 #cmakedefine HAVE_STRING_H
 #cmakedefine HAVE_STDLIB_H
+#cmakedefine HAVE_REGEX_H 1
 
 /* Build options */
 #cmakedefine ENABLE_ASAN
@@ -58,4 +59,4 @@
 /* Install prefix for libdap */
 #define LIBDAP_ROOT "@LIBDAP_ROOT@"
 
-#endif //S_WORKS_CONFIG_DAP_H_IN_H
+#endif //CONFIG_H_IN_H

--- a/config_dap.h
+++ b/config_dap.h
@@ -4,11 +4,7 @@
 #ifndef _config_dap_h
 #define _config_dap_h
 
-#ifdef HAVE_CONFIG_H
-
 #include "config.h"
-
-#endif /* HAVE_CONFIG_H */
 
 /* Shorthand for gcc's unused attribute feature */
 #if defined(__GNUG__) || defined(__GNUC__)

--- a/d4_ce/CMakeLists.txt
+++ b/d4_ce/CMakeLists.txt
@@ -53,7 +53,7 @@ set(D4_CE_LIB_SOURCES
 )
 
 # Define library (static, as 'noinst_LTLIBRARIES' implies not installed)
-add_library(d4_ce_parser STATIC ${D4_CE_LIB_SOURCES})
+add_library(d4_ce_parser OBJECT ${D4_CE_LIB_SOURCES})
 set_target_properties(d4_ce_parser PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Include generated headers

--- a/d4_function/CMakeLists.txt
+++ b/d4_function/CMakeLists.txt
@@ -53,7 +53,7 @@ set(D4_FUNCTION_LIB_SOURCES
 )
 
 # Define a static library
-add_library(d4_function_parser STATIC ${D4_FUNCTION_LIB_SOURCES})
+add_library(d4_function_parser OBJECT ${D4_FUNCTION_LIB_SOURCES})
 set_target_properties(d4_function_parser PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Include directories (including generated files)

--- a/dap-config.in.cmake
+++ b/dap-config.in.cmake
@@ -1,0 +1,106 @@
+#! /bin/sh
+#
+# Borrowed the idea for this script (and some code) from libcurl.
+#
+
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+includedir="${prefix}/include/libdap"
+libdir="${prefix}/lib"
+libdir64=${prefix}/lib64
+
+cflags="-I${includedir} @CURL_PKG_CFLAGS@ @XML2_PKG_CFLAGS@ @TIRPC_PKG_CFLAGS@"
+libs="-L${libdir} -L${libdir64} -ldapclient -ldapserver -ldap @CURL_PKG_LIBS@ @XML2_PKG_LIBS@ @TIRPC_PKG_LIBS@"
+
+# may need to add  @PTHREAD_LIBRARIES@ @UUID_LIB@ 6/25/25 jhrg
+
+usage()
+{
+    cat <<EOF
+Usage: dap-config [OPTION]
+
+Available values for OPTION include:
+
+  --help      	display this help message and exit
+  --cc        	C compiler
+  --cxx       	C++ compiler
+  --cflags    	pre-processor and compiler flags
+  --libs      	library linking information for libdap (both clients and servers)
+  --server-libs libraries for servers
+  --client-libs libraries for clients
+  --prefix    	OPeNDAP install prefix
+  --version   	Library version
+EOF
+
+    exit "$1"
+}
+
+if test $# -eq 0; then
+    usage 1
+fi
+
+while test $# -gt 0; do
+    case "$1" in
+    # this deals with options in the style
+    # --option=value and extracts the value part
+    # [not currently used]
+    -*=*) value=`echo "$1" | sed 's/[-_a-zA-Z0-9]*=//'` ;;
+    *) value= ;;
+    esac
+
+    case "$1" in
+    --help)
+	usage 0
+	;;
+
+    --cc)
+	echo "@CC@"
+	;;
+
+    --cxx)
+	echo "@CXX@"
+	;;
+
+    # Added -I${includedir} so that code can use #include <libdap/Array.h>, ...
+    # which avoids issues with IDE warnings and will help later when there are
+    # two libdap libraries. jhrg 6/17/21
+  --cflags)
+    echo "${cflags}"
+    ;;
+
+  --libs)
+    echo "${libs}"
+    ;;
+
+#
+#   Changed CURL_STATIC_LIBS to CURL_LIBS because the former was including a
+#   a boatload of crypto stuff that might or might not be present on a server.
+#   Various handlers use this script to determine which libraries to link with.
+#   jhrg 2/7/12
+
+    --server-libs)
+       	echo "${libs}"
+       	;;
+
+    --client-libs)
+       	echo "${libs}"
+       	;;
+
+    --prefix)
+       	echo "${prefix}"
+       	;;
+
+    --version)
+		echo "libdap @LIBDAP_VERSION@"
+		;;
+
+    *)
+        echo "unknown option: $1"
+		usage
+		exit 1
+		;;
+    esac
+    shift
+done
+
+exit 0

--- a/dap-config.in.cmake
+++ b/dap-config.in.cmake
@@ -5,12 +5,12 @@
 
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix="${prefix}"
-includedir="${prefix}/include/libdap"
+includedir="${prefix}/include"
 libdir="${prefix}/lib"
 libdir64=${prefix}/lib64
 
-cflags="-I${includedir} @CURL_PKG_CFLAGS@ @XML2_PKG_CFLAGS@ @TIRPC_PKG_CFLAGS@"
-libs="-L${libdir} -L${libdir64} -ldapclient -ldapserver -ldap @CURL_PKG_LIBS@ @XML2_PKG_LIBS@ @TIRPC_PKG_LIBS@"
+cflags="-I${includedir} -I${includedir}/libdap @CURL_PKG_CFLAGS@ @XML2_PKG_CFLAGS@ @TIRPC_PKG_CFLAGS@"
+libs="-L${libdir} -L${libdir64} -ldap -ldapclient -ldapserver @CURL_PKG_LIBS@ @XML2_PKG_LIBS@ @TIRPC_PKG_LIBS@"
 
 # may need to add  @PTHREAD_LIBRARIES@ @UUID_LIB@ 6/25/25 jhrg
 

--- a/http_dap/CMakeLists.txt
+++ b/http_dap/CMakeLists.txt
@@ -36,7 +36,7 @@ set(HTTP_DAP_SOURCES
 )
 
 # Create static library (noinst_LTLIBRARIES implies not installed directly)
-add_library(http_dap STATIC ${HTTP_DAP_SOURCES})
+add_library(http_dap OBJECT ${HTTP_DAP_SOURCES})
 set_target_properties(http_dap PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Include directories (matching AM_CPPFLAGS)

--- a/libdap.pc.in.cmake
+++ b/libdap.pc.in.cmake
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include/libdap
+
+Name: libdap
+Description: OPeNDAP Data Access Protocol library
+Version: @LIBDAP_VERSION@
+Requires:
+Libs: -L${libdir} -ldap @LIBDAP_PKG_LIBS@
+Cflags: -I${includedir} @LIBDAP_PKG_CFLAGS@

--- a/libdap.pc.in.cmake
+++ b/libdap.pc.in.cmake
@@ -1,11 +1,11 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
-includedir=${prefix}/include/libdap
+includedir=${prefix}/include
 
 Name: libdap
 Description: OPeNDAP Data Access Protocol library
 Version: @LIBDAP_VERSION@
 Requires:
 Libs: -L${libdir} -ldap @LIBDAP_PKG_LIBS@
-Cflags: -I${includedir} @LIBDAP_PKG_CFLAGS@
+Cflags: -I${includedir} -I${includedir}/libdap @LIBDAP_PKG_CFLAGS@

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,19 +38,20 @@ install(TARGETS test-types
 # I used in the top-level CMakeLists file. It will install every header here
 # which makes it more robust when files change/move but also easier to install
 # something that should be private. 6/27/25 jhrg
-file(GLOB TEST_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+# For example, it was installing the D4ResponseBuilder.h and ResponseBuilder.h
+# headers, but those should not be installed. 6/29/25 jhrg
+#
+# file(GLOB TEST_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 
+set(TEST_HEADERS
+		TestD4Enum.h		TestGrid.h			TestStructure.h TestD4Group.h
+		TestInt16.h			TestTypeFactory.h 	TestD4Opaque.h	TestInt32.h
+		TestUInt16.h 		TestD4Sequence.h	TestInt64.h		TestUInt32.h
+		TestArray.h			TestFloat32.h		TestInt8.h		TestUInt64.h
+		TestByte.h			TestFloat64.h		TestSequence.h	TestUrl.h
+		TestCommon.h		TestFunction.h		TestStr.h
+		D4TestFunction.h	D4TestTypeFactory.h)
+\
 install(FILES ${TEST_HEADERS}
 		DESTINATION include/libdap/test)
 
-#set(TEST_TYPES_HDR
-#		D4ResponseBuilder.h	TestD4Enum.h		TestGrid.h		TestStructure.h
-#		D4TestFunction.h	TestD4Group.h		TestInt16.h		TestTypeFactory.h
-#		D4TestTypeFactory.h	TestD4Opaque.h		TestInt32.h		TestUInt16.h
-#		ResponseBuilder.h	TestD4Sequence.h	TestInt64.h		TestUInt32.h
-#		TestArray.h			TestFloat32.h		TestInt8.h		TestUInt64.h
-#		TestByte.h			TestFloat64.h		TestSequence.h	TestUrl.h
-#		TestCommon.h		TestFunction.h		TestStr.h)
-#
-#install(FILES ${TEST_TYPES_HDR}
-#		DESTINATION include/libdap/test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,8 @@ add_library(test-types STATIC
 		TestCommon.cc TestFloat64.cc TestInt8.cc TestUInt32.cc
 		TestD4Enum.cc TestFunction.cc TestSequence.cc TestUInt64.cc
 		TestD4Group.cc TestGrid.cc TestStr.cc TestUrl.cc
-		TestD4Opaque.cc TestInt16.cc TestStructure.cc
+		TestD4Opaque.cc TestInt16.cc TestStructure.cc D4TestTypeFactory.cc
+		D4TestFunction.cc
 )
 set_target_properties(test-types PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,16 @@ add_library(test-types STATIC
 )
 set_target_properties(test-types PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-target_include_directories(test-types PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+# Replace:
+# target_include_directories(test-types PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+# With the following. This enables linking locally and then installing so
+# library users can link to these without linking to the source tree. 6/27/25 jhrg
+target_include_directories(test-types
+		PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+		$<INSTALL_INTERFACE:include/libdap/test>
+)
+
 target_include_directories(test-types PRIVATE ${LIBXML2_INCLUDE_DIR})
 
 if(TIRPC_FOUND)
@@ -18,3 +27,29 @@ if(TIRPC_FOUND)
 endif()
 
 target_link_libraries(test-types PRIVATE dap)
+
+install(TARGETS test-types
+		EXPORT libdap4Targets
+		ARCHIVE DESTINATION lib
+		INCLUDES DESTINATION include/libdap/test)
+
+# This is an alternative to the set(VAR ...) and install(FILES ...) pattern
+# I used in the top-level CMakeLists file. It will install every header here
+# which makes it more robust when files change/move but also easier to install
+# something that should be private. 6/27/25 jhrg
+file(GLOB TEST_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+install(FILES ${TEST_HEADERS}
+		DESTINATION include/libdap/test)
+
+#set(TEST_TYPES_HDR
+#		D4ResponseBuilder.h	TestD4Enum.h		TestGrid.h		TestStructure.h
+#		D4TestFunction.h	TestD4Group.h		TestInt16.h		TestTypeFactory.h
+#		D4TestTypeFactory.h	TestD4Opaque.h		TestInt32.h		TestUInt16.h
+#		ResponseBuilder.h	TestD4Sequence.h	TestInt64.h		TestUInt32.h
+#		TestArray.h			TestFloat32.h		TestInt8.h		TestUInt64.h
+#		TestByte.h			TestFloat64.h		TestSequence.h	TestUrl.h
+#		TestCommon.h		TestFunction.h		TestStr.h)
+#
+#install(FILES ${TEST_TYPES_HDR}
+#		DESTINATION include/libdap/test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,7 +51,7 @@ set(TEST_HEADERS
 		TestByte.h			TestFloat64.h		TestSequence.h	TestUrl.h
 		TestCommon.h		TestFunction.h		TestStr.h
 		D4TestFunction.h	D4TestTypeFactory.h)
-\
+
 install(FILES ${TEST_HEADERS}
 		DESTINATION include/libdap/test)
 


### PR DESCRIPTION
Add previously missing DAP4 parser libraries to libdap. I did this using cmake's OBJECT
library type which guarantees that the object code in the 'convenience library' will be
copied to the installed library on OSX. There is an issue where statically linking a library
to another library does not move the object code as you'd expect. Odd, because this
appears to work in the BES build with autotools and here with gl when using autotools.