### PR TITLE
Jhrg/hyrax 1849 http test checksums

### DIFF
--- a/http_dap/unit-tests/HTTPThreadsConnectTest.cc
+++ b/http_dap/unit-tests/HTTPThreadsConnectTest.cc
@@ -120,9 +120,9 @@ public:
     CPPUNIT_TEST(fetch_url_test_304_mt_w_cache);
     CPPUNIT_TEST(fetch_url_test_nc_mt);
     CPPUNIT_TEST(fetch_url_test_nc_mt_w_cache);
-#if 0
-      CPPUNIT_TEST_FAIL(fetch_url_test_diff_urls_mt_w_cache);              // See HYRAX-1849
-    CPPUNIT_TEST_FAIL(fetch_url_test_diff_urls_mt_w_cache_multi_access); // See HYRAX-1849
+#if 1
+    CPPUNIT_TEST(fetch_url_test_diff_urls_mt_w_cache);              // See HYRAX-1849
+    CPPUNIT_TEST(fetch_url_test_diff_urls_mt_w_cache_multi_access); // See HYRAX-1849
 #endif
     CPPUNIT_TEST(fetch_url_test_302_urls_mt_w_cache_multi_access);
 
@@ -301,7 +301,7 @@ public:
             vector<Job> jobs = {{netcdf_das_url, das_url, conns[0].get()},
                                 {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dds"), dds_url, conns[1].get()},
                                 {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dmr"), dmr_url, conns[2].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"), dap_url, conns[3].get()}};
+                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=true"), dap_url, conns[3].get()}};
 
             vector<future<void>> futures;
             futures.reserve(jobs.size());
@@ -341,7 +341,7 @@ public:
                 {netcdf_das_url, das_url, conns[0].get()},
                 {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dds"), dds_url, conns[1].get()},
                 {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dmr"), dmr_url, conns[2].get()},
-                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"), dap_url, conns[3].get()}};
+                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=true"), dap_url, conns[3].get()}};
             vector<Job> jobs_repeat = jobs_first;
 
             auto run_jobs = [&](const vector<Job> &jobs) {

--- a/http_dap/unit-tests/HTTPThreadsConnectTest.cc
+++ b/http_dap/unit-tests/HTTPThreadsConnectTest.cc
@@ -362,7 +362,7 @@ public:
 
             string netcdf_dds_url{"http://test.opendap.org/dap/data/nc/fnoc1.nc.dds"};
             string netcdf_dmr_url{"http://test.opendap.org/dap/data/nc/fnoc1.nc.dmr"};
-            string netcdf_dap_url{"http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"};
+            string netcdf_dap_url{"http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=true"};
 
             std::thread thread1(hc_lambda, netcdf_das_url, http_1.get(), 927);
             std::thread thread2(hc_lambda, netcdf_dds_url, http_2.get(), 197);
@@ -413,7 +413,7 @@ public:
 
             string netcdf_dds_url{"http://test.opendap.org/dap/data/nc/fnoc1.nc.dds"};
             string netcdf_dmr_url{"http://test.opendap.org/dap/data/nc/fnoc1.nc.dmr"};
-            string netcdf_dap_url{"http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"};
+            string netcdf_dap_url{"http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=true"};
 
             std::thread thread1(hc_lambda, netcdf_das_url, http_1.get(), 927);
             std::thread thread2(hc_lambda, netcdf_dds_url, http_2.get(), 197);

--- a/http_dap/unit-tests/HTTPThreadsConnectTest.cc
+++ b/http_dap/unit-tests/HTTPThreadsConnectTest.cc
@@ -122,7 +122,7 @@ public:
     CPPUNIT_TEST(fetch_url_test_nc_mt);
     CPPUNIT_TEST(fetch_url_test_nc_mt_w_cache);
 #if 1
-    // See HYRAX-1849
+    // See HYRAX-1849 
     CPPUNIT_TEST(fetch_url_test_dap_url_no_crc_mt_w_cache);
     CPPUNIT_TEST(fetch_url_test_dap_url_no_crc_no_key_mt_w_cache);
     CPPUNIT_TEST(fetch_url_test_diff_urls_mt_w_cache);

--- a/http_dap/unit-tests/HTTPThreadsConnectTest.cc
+++ b/http_dap/unit-tests/HTTPThreadsConnectTest.cc
@@ -73,7 +73,7 @@ const auto dds_url = 197;
 const auto das_url = 927;
 
 inline static uint64_t file_size(FILE *fp) {
-    struct stat s {};
+    struct stat s{};
     fstat(fileno(fp), &s);
     return s.st_size;
 }
@@ -122,7 +122,7 @@ public:
     CPPUNIT_TEST(fetch_url_test_nc_mt);
     CPPUNIT_TEST(fetch_url_test_nc_mt_w_cache);
 #if 1
-    // See HYRAX-1849 
+    // See HYRAX-1849
     CPPUNIT_TEST(fetch_url_test_dap_url_no_crc_mt_w_cache);
     CPPUNIT_TEST(fetch_url_test_dap_url_no_crc_no_key_mt_w_cache);
     CPPUNIT_TEST(fetch_url_test_diff_urls_mt_w_cache);
@@ -302,14 +302,10 @@ public:
                 uint32_t sz;
                 HTTPConnect *hc;
             };
-            vector<Job> jobs = {{string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),
-                                 dap_url_no_crc, conns[0].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),
-                                 dap_url_no_crc, conns[1].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),
-                                 dap_url_no_crc, conns[2].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),
-                                 dap_url_no_crc, conns[3].get()}};
+            vector<Job> jobs = {{string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),dap_url_no_crc, conns[0].get()},
+                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),dap_url_no_crc, conns[1].get()},
+                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),dap_url_no_crc, conns[2].get()},
+                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),dap_url_no_crc, conns[3].get()}};
 
             vector<future<void>> futures;
             futures.reserve(jobs.size());
@@ -343,14 +339,11 @@ public:
                 uint32_t sz;
                 HTTPConnect *hc;
             };
-            vector<Job> jobs = {{string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"),
-                                 dap_url_no_crc, conns[0].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"),
-                                 dap_url_no_crc, conns[1].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"),
-                                 dap_url_no_crc, conns[2].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"),
-                                 dap_url_no_crc, conns[3].get()}};
+            vector<Job> jobs = {
+                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"), dap_url_no_crc, conns[0].get()},
+                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"), dap_url_no_crc, conns[1].get()},
+                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"), dap_url_no_crc, conns[2].get()},
+                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap"), dap_url_no_crc, conns[3].get()}};
 
             vector<future<void>> futures;
             futures.reserve(jobs.size());

--- a/http_dap/unit-tests/HTTPThreadsConnectTest.cc
+++ b/http_dap/unit-tests/HTTPThreadsConnectTest.cc
@@ -73,7 +73,7 @@ const auto dds_url = 197;
 const auto das_url = 927;
 
 inline static uint64_t file_size(FILE *fp) {
-    struct stat s{};
+    struct stat s {};
     fstat(fileno(fp), &s);
     return s.st_size;
 }
@@ -302,10 +302,14 @@ public:
                 uint32_t sz;
                 HTTPConnect *hc;
             };
-            vector<Job> jobs = {{string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),dap_url_no_crc, conns[0].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),dap_url_no_crc, conns[1].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),dap_url_no_crc, conns[2].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),dap_url_no_crc, conns[3].get()}};
+            vector<Job> jobs = {{string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),
+                                 dap_url_no_crc, conns[0].get()},
+                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),
+                                 dap_url_no_crc, conns[1].get()},
+                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),
+                                 dap_url_no_crc, conns[2].get()},
+                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=false"),
+                                 dap_url_no_crc, conns[3].get()}};
 
             vector<future<void>> futures;
             futures.reserve(jobs.size());

--- a/http_dap/unit-tests/HTTPThreadsConnectTest.cc
+++ b/http_dap/unit-tests/HTTPThreadsConnectTest.cc
@@ -301,7 +301,8 @@ public:
             vector<Job> jobs = {{netcdf_das_url, das_url, conns[0].get()},
                                 {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dds"), dds_url, conns[1].get()},
                                 {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dmr"), dmr_url, conns[2].get()},
-                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=true"), dap_url, conns[3].get()}};
+                                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=true"), dap_url,
+                                 conns[3].get()}};
 
             vector<future<void>> futures;
             futures.reserve(jobs.size());
@@ -341,7 +342,8 @@ public:
                 {netcdf_das_url, das_url, conns[0].get()},
                 {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dds"), dds_url, conns[1].get()},
                 {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dmr"), dmr_url, conns[2].get()},
-                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=true"), dap_url, conns[3].get()}};
+                {string("http://test.opendap.org/dap/data/nc/fnoc1.nc.dap?dap4.checksum=true"), dap_url,
+                 conns[3].get()}};
             vector<Job> jobs_repeat = jobs_first;
 
             auto run_jobs = [&](const vector<Job> &jobs) {

--- a/http_dap/unit-tests/HTTPThreadsConnectTest.cc
+++ b/http_dap/unit-tests/HTTPThreadsConnectTest.cc
@@ -122,10 +122,11 @@ public:
     CPPUNIT_TEST(fetch_url_test_nc_mt);
     CPPUNIT_TEST(fetch_url_test_nc_mt_w_cache);
 #if 1
+    // See HYRAX-1849
     CPPUNIT_TEST(fetch_url_test_dap_url_no_crc_mt_w_cache);
     CPPUNIT_TEST(fetch_url_test_dap_url_no_crc_no_key_mt_w_cache);
-    CPPUNIT_TEST(fetch_url_test_diff_urls_mt_w_cache);              // See HYRAX-1849
-    CPPUNIT_TEST(fetch_url_test_diff_urls_mt_w_cache_multi_access); // See HYRAX-1849
+    CPPUNIT_TEST(fetch_url_test_diff_urls_mt_w_cache);
+    CPPUNIT_TEST(fetch_url_test_diff_urls_mt_w_cache_multi_access);
 #endif
     CPPUNIT_TEST(fetch_url_test_302_urls_mt_w_cache_multi_access);
 


### PR DESCRIPTION
This pull request fixes the tests of HTTPConnect - particularly the multithreaded tests - so that
they work with DAP4 data responses either do or do not include empty end chunks when checksums 
are not requested.

If the checksum behavior is changed, these tests will likely need to be updated.