### PR TITLE
Jhrg/hyrax 1855 warnings

### DIFF
--- a/AttrTable.h
+++ b/AttrTable.h
@@ -356,7 +356,7 @@ public:
 
     void print_dap4(XMLWriter &xml);
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 string remove_space_encoding(const string &s);

--- a/D4Attributes.h
+++ b/D4Attributes.h
@@ -92,7 +92,7 @@ public:
 
     void print_dap4(XMLWriter &xml) const;
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 class D4Attributes : public DapObj {
@@ -161,7 +161,7 @@ public:
 
     void print_dap4(XMLWriter &xml) const;
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 string D4AttributeTypeToString(D4AttributeType at);

--- a/D4Connect.cc
+++ b/D4Connect.cc
@@ -149,8 +149,11 @@ void D4Connect::process_data(DMR &data, Response &rs) {
                 throw Error("Found an unexpected end of input (EOF) while reading a DAP4 data response. (1)");
 
             // get chunk
+            vector<char> chunk(chunk_size);
+#if 0
             char chunk[chunk_size];
-            cis.read(chunk, chunk_size);
+#endif
+            cis.read(chunk.data(), chunk_size);
             // parse char * with given size
             D4ParserSax2 parser;
             // permissive mode allows references to Maps that are not in the response.
@@ -158,7 +161,7 @@ void D4Connect::process_data(DMR &data, Response &rs) {
             parser.set_strict(false);
 
             // '-2' to discard the CRLF pair
-            parser.intern(chunk, chunk_size - 2, &data);
+            parser.intern(chunk.data(), chunk_size - 2, &data);
         } catch (Error &e) {
             cerr << "Exception: " << e.get_error_message() << endl;
             return;
@@ -383,15 +386,18 @@ void D4Connect::request_dap4_data(DMR &dmr, const string &dap4_ce) {
             if (chunk_size < 0)
                 throw Error("Found an unexpected end of input (EOF) while reading a DAP4 data response. (2)");
 
-            // get chunk
+                // get chunk
+#if 0
             char chunk[chunk_size];
-            cis.read(chunk, chunk_size);
+#endif
+            vector<char> chunk(chunk_size);
+            cis.read(chunk.data(), chunk_size);
             // parse char * with given size
             D4ParserSax2 parser;
             // permissive mode allows references to Maps that are not in the response.
             parser.set_strict(false);
             // '-2' to discard the CRLF pair
-            parser.intern(chunk, chunk_size - 2, &dmr, false /*debug*/);
+            parser.intern(chunk.data(), chunk_size - 2, &dmr, false /*debug*/);
 
             // Read data and store in the DMR
             D4StreamUnMarshaller um(cis, cis.twiddle_bytes());

--- a/D4Connect.cc
+++ b/D4Connect.cc
@@ -150,9 +150,6 @@ void D4Connect::process_data(DMR &data, Response &rs) {
 
             // get chunk
             vector<char> chunk(chunk_size);
-#if 0
-            char chunk[chunk_size];
-#endif
             cis.read(chunk.data(), chunk_size);
             // parse char * with given size
             D4ParserSax2 parser;
@@ -386,10 +383,7 @@ void D4Connect::request_dap4_data(DMR &dmr, const string &dap4_ce) {
             if (chunk_size < 0)
                 throw Error("Found an unexpected end of input (EOF) while reading a DAP4 data response. (2)");
 
-                // get chunk
-#if 0
-            char chunk[chunk_size];
-#endif
+            // get chunk
             vector<char> chunk(chunk_size);
             cis.read(chunk.data(), chunk_size);
             // parse char * with given size

--- a/D4StreamUnMarshaller.h
+++ b/D4StreamUnMarshaller.h
@@ -109,43 +109,43 @@ public:
     string get_checksum_str();
     int64_t get_count();
 
-    virtual void get_byte(dods_byte &val);
+    virtual void get_byte(dods_byte &val) override;
     virtual void get_int8(dods_int8 &val);
 
-    virtual void get_int16(dods_int16 &val);
-    virtual void get_int32(dods_int32 &val);
+    virtual void get_int16(dods_int16 &val) override;
+    virtual void get_int32(dods_int32 &val) override;
 
     virtual void get_int64(dods_int64 &val);
 
-    virtual void get_float32(dods_float32 &val);
-    virtual void get_float64(dods_float64 &val);
+    virtual void get_float32(dods_float32 &val) override;
+    virtual void get_float64(dods_float64 &val) override;
 
-    virtual void get_uint16(dods_uint16 &val);
-    virtual void get_uint32(dods_uint32 &val);
+    virtual void get_uint16(dods_uint16 &val) override;
+    virtual void get_uint32(dods_uint32 &val) override;
 
     virtual void get_uint64(dods_uint64 &val);
 
-    virtual void get_str(string &val);
-    virtual void get_url(string &val);
+    virtual void get_str(string &val) override;
+    virtual void get_url(string &val) override;
 
-    virtual void get_opaque(char *, unsigned int) {
+    virtual void get_opaque(char *, unsigned int) override {
         throw InternalErr(__FILE__, __LINE__, "Not implemented for DAP4, use get_opaque_dap4() instead.");
     }
 
     virtual void get_opaque_dap4(char **val, int64_t &len);
     virtual void get_opaque_dap4(vector<uint8_t> &val);
 
-    virtual void get_int(int &) { throw InternalErr(__FILE__, __LINE__, "Not implemented for DAP4"); }
+    virtual void get_int(int &) override { throw InternalErr(__FILE__, __LINE__, "Not implemented for DAP4"); }
 
     // Note that DAP4 assumes clients know the size of arrays when they
     // read the data; it's the 'varying' get methods that read & return the
     // number of elements. These methods are here to appease the UnMarshaller
     // 'interface' code
-    virtual void get_vector(char **, unsigned int &, Vector &) {
+    virtual void get_vector(char **, unsigned int &, Vector &) override {
         throw InternalErr(__FILE__, __LINE__, "Not implemented for DAP4");
     }
 
-    virtual void get_vector(char **, unsigned int &, int, Vector &) {
+    virtual void get_vector(char **, unsigned int &, int, Vector &) override {
         throw InternalErr(__FILE__, __LINE__, "Not implemented for DAP4");
     }
 
@@ -154,7 +154,7 @@ public:
     virtual void get_vector_float32(char *val, int64_t num_elem);
     virtual void get_vector_float64(char *val, int64_t num_elem);
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/D4StreamUnMarshaller.h
+++ b/D4StreamUnMarshaller.h
@@ -109,43 +109,43 @@ public:
     string get_checksum_str();
     int64_t get_count();
 
-    virtual void get_byte(dods_byte &val) override;
+    void get_byte(dods_byte &val) override;
     virtual void get_int8(dods_int8 &val);
 
-    virtual void get_int16(dods_int16 &val) override;
-    virtual void get_int32(dods_int32 &val) override;
+    void get_int16(dods_int16 &val) override;
+    void get_int32(dods_int32 &val) override;
 
     virtual void get_int64(dods_int64 &val);
 
-    virtual void get_float32(dods_float32 &val) override;
-    virtual void get_float64(dods_float64 &val) override;
+    void get_float32(dods_float32 &val) override;
+    void get_float64(dods_float64 &val) override;
 
-    virtual void get_uint16(dods_uint16 &val) override;
-    virtual void get_uint32(dods_uint32 &val) override;
+    void get_uint16(dods_uint16 &val) override;
+    void get_uint32(dods_uint32 &val) override;
 
     virtual void get_uint64(dods_uint64 &val);
 
-    virtual void get_str(string &val) override;
-    virtual void get_url(string &val) override;
+    void get_str(string &val) override;
+    void get_url(string &val) override;
 
-    virtual void get_opaque(char *, unsigned int) override {
+    void get_opaque(char *, unsigned int) override {
         throw InternalErr(__FILE__, __LINE__, "Not implemented for DAP4, use get_opaque_dap4() instead.");
     }
 
     virtual void get_opaque_dap4(char **val, int64_t &len);
     virtual void get_opaque_dap4(vector<uint8_t> &val);
 
-    virtual void get_int(int &) override { throw InternalErr(__FILE__, __LINE__, "Not implemented for DAP4"); }
+    void get_int(int &) override { throw InternalErr(__FILE__, __LINE__, "Not implemented for DAP4"); }
 
     // Note that DAP4 assumes clients know the size of arrays when they
     // read the data; it's the 'varying' get methods that read & return the
     // number of elements. These methods are here to appease the UnMarshaller
     // 'interface' code
-    virtual void get_vector(char **, unsigned int &, Vector &) override {
+    void get_vector(char **, unsigned int &, Vector &) override {
         throw InternalErr(__FILE__, __LINE__, "Not implemented for DAP4");
     }
 
-    virtual void get_vector(char **, unsigned int &, int, Vector &) override {
+    void get_vector(char **, unsigned int &, int, Vector &) override {
         throw InternalErr(__FILE__, __LINE__, "Not implemented for DAP4");
     }
 

--- a/DAPCache3.h
+++ b/DAPCache3.h
@@ -151,7 +151,7 @@ public:
     static BESCache3 *get_instance(BESKeys *keys, const string &cache_dir_key, const string &prefix_key, const string &size_key);
 #endif
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/DAS.h
+++ b/DAS.h
@@ -189,7 +189,7 @@ public:
     virtual void print(FILE *out, bool dereference = false);
     virtual void print(ostream &out, bool dereference = false);
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/DDS.h
+++ b/DDS.h
@@ -399,7 +399,7 @@ public:
 
     bool is_dap4_projected(std::vector<string> &inventory);
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/DataDDS.h
+++ b/DataDDS.h
@@ -115,7 +115,7 @@ public:
     int get_protocol_major() const { return d_server_protocol_major; }
     int get_protocol_minor() const { return d_server_protocol_minor; }
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/Grid.h
+++ b/Grid.h
@@ -137,14 +137,14 @@ public:
     typedef std::vector<BaseType *>::reverse_iterator Map_riter;
 
     Grid &operator=(const Grid &rhs);
-    virtual BaseType *ptr_duplicate() override;
+    BaseType *ptr_duplicate() override;
 
-    virtual void transform_to_dap4(D4Group *root, Constructor *container) override;
+    void transform_to_dap4(D4Group *root, Constructor *container) override;
 
     virtual bool is_dap2_only_type();
 
-    virtual void add_var(BaseType *bt, Part part) override;
-    virtual void add_var_nocopy(BaseType *bt, Part part) override;
+    void add_var(BaseType *bt, Part part) override;
+    void add_var_nocopy(BaseType *bt, Part part) override;
 
     virtual void set_array(Array *p_new_arr);
     virtual Array *add_map(Array *p_new_map, bool add_copy);
@@ -164,19 +164,19 @@ public:
     virtual void print_decl(ostream &out, string space = "    ", bool print_semi = true, bool constraint_info = false,
                             bool constrained = false) override;
 
-    virtual void print_xml(ostream &out, string space = "    ", bool constrained = false) override;
-    virtual void print_xml_writer(XMLWriter &xml, bool constrained = false) override;
+    void print_xml(ostream &out, string space = "    ", bool constrained = false) override;
+    void print_xml_writer(XMLWriter &xml, bool constrained = false) override;
 
-    virtual void print_val(ostream &out, string space = "", bool print_decl_p = true) override;
+    void print_val(ostream &out, string space = "", bool print_decl_p = true) override;
 
     virtual void print_decl(FILE *out, string space = "    ", bool print_semi = true, bool constraint_info = false,
                             bool constrained = false) override;
-    virtual void print_xml(FILE *out, string space = "    ", bool constrained = false) override;
-    virtual void print_val(FILE *out, string space = "", bool print_decl_p = true) override;
+    void print_xml(FILE *out, string space = "    ", bool constrained = false) override;
+    void print_val(FILE *out, string space = "", bool print_decl_p = true) override;
 
-    virtual void transfer_attributes(AttrTable *at_container) override;
+    void transfer_attributes(AttrTable *at_container) override;
 
-    virtual bool check_semantics(string &msg, bool all = false) override;
+    bool check_semantics(string &msg, bool all = false) override;
 
     Map_iter map_begin();
     Map_iter map_end();

--- a/Grid.h
+++ b/Grid.h
@@ -137,14 +137,14 @@ public:
     typedef std::vector<BaseType *>::reverse_iterator Map_riter;
 
     Grid &operator=(const Grid &rhs);
-    virtual BaseType *ptr_duplicate();
+    virtual BaseType *ptr_duplicate() override;
 
-    virtual void transform_to_dap4(D4Group *root, Constructor *container);
+    virtual void transform_to_dap4(D4Group *root, Constructor *container) override;
 
     virtual bool is_dap2_only_type();
 
-    virtual void add_var(BaseType *bt, Part part);
-    virtual void add_var_nocopy(BaseType *bt, Part part);
+    virtual void add_var(BaseType *bt, Part part) override;
+    virtual void add_var_nocopy(BaseType *bt, Part part) override;
 
     virtual void set_array(Array *p_new_arr);
     virtual Array *add_map(Array *p_new_map, bool add_copy);
@@ -162,21 +162,21 @@ public:
     virtual void clear_constraint();
 
     virtual void print_decl(ostream &out, string space = "    ", bool print_semi = true, bool constraint_info = false,
-                            bool constrained = false);
+                            bool constrained = false) override;
 
-    virtual void print_xml(ostream &out, string space = "    ", bool constrained = false);
-    virtual void print_xml_writer(XMLWriter &xml, bool constrained = false);
+    virtual void print_xml(ostream &out, string space = "    ", bool constrained = false) override;
+    virtual void print_xml_writer(XMLWriter &xml, bool constrained = false) override;
 
-    virtual void print_val(ostream &out, string space = "", bool print_decl_p = true);
+    virtual void print_val(ostream &out, string space = "", bool print_decl_p = true) override;
 
     virtual void print_decl(FILE *out, string space = "    ", bool print_semi = true, bool constraint_info = false,
-                            bool constrained = false);
-    virtual void print_xml(FILE *out, string space = "    ", bool constrained = false);
-    virtual void print_val(FILE *out, string space = "", bool print_decl_p = true);
+                            bool constrained = false) override;
+    virtual void print_xml(FILE *out, string space = "    ", bool constrained = false) override;
+    virtual void print_val(FILE *out, string space = "", bool print_decl_p = true) override;
 
-    virtual void transfer_attributes(AttrTable *at_container);
+    virtual void transfer_attributes(AttrTable *at_container) override;
 
-    virtual bool check_semantics(string &msg, bool all = false);
+    virtual bool check_semantics(string &msg, bool all = false) override;
 
     Map_iter map_begin();
     Map_iter map_end();
@@ -184,7 +184,7 @@ public:
     Map_riter map_rend();
     Map_iter get_map_iter(int i);
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/Sequence.h
+++ b/Sequence.h
@@ -227,27 +227,27 @@ public:
 
     Sequence &operator=(const Sequence &rhs);
 
-    virtual BaseType *ptr_duplicate();
+    virtual BaseType *ptr_duplicate() override;
 
-    virtual void clear_local_data();
+    virtual void clear_local_data() override;
 
-    virtual void transform_to_dap4(D4Group *root, Constructor *container);
+    virtual void transform_to_dap4(D4Group *root, Constructor *container) override;
 
     virtual bool is_dap2_only_type();
 
-    virtual string toString();
+    virtual string toString() override;
 
-    virtual bool is_linear();
+    virtual bool is_linear() override;
 
-    virtual int length() const;
+    virtual int length() const override;
 
     virtual int number_of_rows() const;
 
     virtual bool read_row(int row, DDS &dds, ConstraintEvaluator &eval, bool ce_eval = true);
 
-    virtual void intern_data(ConstraintEvaluator &eval, DDS &dds);
-    virtual bool serialize(ConstraintEvaluator &eval, DDS &dds, Marshaller &m, bool ce_eval = true);
-    virtual bool deserialize(UnMarshaller &um, DDS *dds, bool reuse = false);
+    virtual void intern_data(ConstraintEvaluator &eval, DDS &dds) override;
+    virtual bool serialize(ConstraintEvaluator &eval, DDS &dds, Marshaller &m, bool ce_eval = true) override;
+    virtual bool deserialize(UnMarshaller &um, DDS *dds, bool reuse = false) override;
 
     /// Rest the row number counter
     void reset_row_number();
@@ -283,12 +283,12 @@ public:
     virtual void print_one_row(ostream &out, int row, string space, bool print_row_num = false);
     virtual void print_val_by_rows(ostream &out, string space = "", bool print_decl_p = true,
                                    bool print_row_numbers = true);
-    virtual void print_val(ostream &out, string space = "", bool print_decl_p = true);
+    virtual void print_val(ostream &out, string space = "", bool print_decl_p = true) override;
 
     virtual void print_one_row(FILE *out, int row, string space, bool print_row_num = false);
     virtual void print_val_by_rows(FILE *out, string space = "", bool print_decl_p = true,
                                    bool print_row_numbers = true);
-    virtual void print_val(FILE *out, string space = "", bool print_decl_p = true);
+    virtual void print_val(FILE *out, string space = "", bool print_decl_p = true) override;
 
     virtual void set_leaf_p(bool state);
 
@@ -296,7 +296,7 @@ public:
 
     virtual void set_leaf_sequence(int lvl = 1);
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/Sequence.h
+++ b/Sequence.h
@@ -227,27 +227,27 @@ public:
 
     Sequence &operator=(const Sequence &rhs);
 
-    virtual BaseType *ptr_duplicate() override;
+    BaseType *ptr_duplicate() override;
 
-    virtual void clear_local_data() override;
+    void clear_local_data() override;
 
-    virtual void transform_to_dap4(D4Group *root, Constructor *container) override;
+    void transform_to_dap4(D4Group *root, Constructor *container) override;
 
     virtual bool is_dap2_only_type();
 
-    virtual string toString() override;
+    string toString() override;
 
-    virtual bool is_linear() override;
+    bool is_linear() override;
 
-    virtual int length() const override;
+    int length() const override;
 
     virtual int number_of_rows() const;
 
     virtual bool read_row(int row, DDS &dds, ConstraintEvaluator &eval, bool ce_eval = true);
 
-    virtual void intern_data(ConstraintEvaluator &eval, DDS &dds) override;
-    virtual bool serialize(ConstraintEvaluator &eval, DDS &dds, Marshaller &m, bool ce_eval = true) override;
-    virtual bool deserialize(UnMarshaller &um, DDS *dds, bool reuse = false) override;
+    void intern_data(ConstraintEvaluator &eval, DDS &dds) override;
+    bool serialize(ConstraintEvaluator &eval, DDS &dds, Marshaller &m, bool ce_eval = true) override;
+    bool deserialize(UnMarshaller &um, DDS *dds, bool reuse = false) override;
 
     /// Rest the row number counter
     void reset_row_number();
@@ -283,12 +283,12 @@ public:
     virtual void print_one_row(ostream &out, int row, string space, bool print_row_num = false);
     virtual void print_val_by_rows(ostream &out, string space = "", bool print_decl_p = true,
                                    bool print_row_numbers = true);
-    virtual void print_val(ostream &out, string space = "", bool print_decl_p = true) override;
+    void print_val(ostream &out, string space = "", bool print_decl_p = true) override;
 
     virtual void print_one_row(FILE *out, int row, string space, bool print_row_num = false);
     virtual void print_val_by_rows(FILE *out, string space = "", bool print_decl_p = true,
                                    bool print_row_numbers = true);
-    virtual void print_val(FILE *out, string space = "", bool print_decl_p = true) override;
+    void print_val(FILE *out, string space = "", bool print_decl_p = true) override;
 
     virtual void set_leaf_p(bool state);
 

--- a/Structure.h
+++ b/Structure.h
@@ -90,16 +90,16 @@ public:
     virtual ~Structure();
 
     Structure &operator=(const Structure &rhs);
-    virtual BaseType *ptr_duplicate();
+    virtual BaseType *ptr_duplicate() override;
 
-    virtual void transform_to_dap4(D4Group *root, Constructor *container);
+    virtual void transform_to_dap4(D4Group *root, Constructor *container) override;
     std::vector<BaseType *> *transform_to_dap2(AttrTable *parent_attr_table, bool show_shared_dims = false) override;
 
-    virtual bool is_linear();
+    virtual bool is_linear() override;
 
     virtual void set_leaf_sequence(int level = 1);
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/Structure.h
+++ b/Structure.h
@@ -90,12 +90,12 @@ public:
     virtual ~Structure();
 
     Structure &operator=(const Structure &rhs);
-    virtual BaseType *ptr_duplicate() override;
+    BaseType *ptr_duplicate() override;
 
-    virtual void transform_to_dap4(D4Group *root, Constructor *container) override;
+    void transform_to_dap4(D4Group *root, Constructor *container) override;
     std::vector<BaseType *> *transform_to_dap2(AttrTable *parent_attr_table, bool show_shared_dims = false) override;
 
-    virtual bool is_linear() override;
+    bool is_linear() override;
 
     virtual void set_leaf_sequence(int level = 1);
 

--- a/XDRFileMarshaller.h
+++ b/XDRFileMarshaller.h
@@ -52,27 +52,27 @@ public:
     XDRFileMarshaller(FILE *out);
     virtual ~XDRFileMarshaller();
 
-    virtual void put_byte(dods_byte val);
+    virtual void put_byte(dods_byte val) override;
 
-    virtual void put_int16(dods_int16 val);
-    virtual void put_int32(dods_int32 val);
+    virtual void put_int16(dods_int16 val) override;
+    virtual void put_int32(dods_int32 val) override;
 
-    virtual void put_float32(dods_float32 val);
-    virtual void put_float64(dods_float64 val);
+    virtual void put_float32(dods_float32 val) override;
+    virtual void put_float64(dods_float64 val) override;
 
-    virtual void put_uint16(dods_uint16 val);
-    virtual void put_uint32(dods_uint32 val);
+    virtual void put_uint16(dods_uint16 val) override;
+    virtual void put_uint32(dods_uint32 val) override;
 
-    virtual void put_str(const string &val);
-    virtual void put_url(const string &val);
+    virtual void put_str(const string &val) override;
+    virtual void put_url(const string &val) override;
 
-    virtual void put_opaque(char *val, unsigned int len);
-    virtual void put_int(int val);
+    virtual void put_opaque(char *val, unsigned int len) override;
+    virtual void put_int(int val) override;
 
-    virtual void put_vector(char *val, int num, Vector &vec);
-    virtual void put_vector(char *val, int num, int width, Vector &vec);
+    virtual void put_vector(char *val, int num, Vector &vec) override;
+    virtual void put_vector(char *val, int num, int width, Vector &vec) override;
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/XDRFileMarshaller.h
+++ b/XDRFileMarshaller.h
@@ -52,25 +52,25 @@ public:
     XDRFileMarshaller(FILE *out);
     virtual ~XDRFileMarshaller();
 
-    virtual void put_byte(dods_byte val) override;
+    void put_byte(dods_byte val) override;
 
-    virtual void put_int16(dods_int16 val) override;
-    virtual void put_int32(dods_int32 val) override;
+    void put_int16(dods_int16 val) override;
+    void put_int32(dods_int32 val) override;
 
-    virtual void put_float32(dods_float32 val) override;
-    virtual void put_float64(dods_float64 val) override;
+    void put_float32(dods_float32 val) override;
+    void put_float64(dods_float64 val) override;
 
-    virtual void put_uint16(dods_uint16 val) override;
-    virtual void put_uint32(dods_uint32 val) override;
+    void put_uint16(dods_uint16 val) override;
+    void put_uint32(dods_uint32 val) override;
 
-    virtual void put_str(const string &val) override;
-    virtual void put_url(const string &val) override;
+    void put_str(const string &val) override;
+    void put_url(const string &val) override;
 
-    virtual void put_opaque(char *val, unsigned int len) override;
-    virtual void put_int(int val) override;
+    void put_opaque(char *val, unsigned int len) override;
+    void put_int(int val) override;
 
-    virtual void put_vector(char *val, int num, Vector &vec) override;
-    virtual void put_vector(char *val, int num, int width, Vector &vec) override;
+    void put_vector(char *val, int num, Vector &vec) override;
+    void put_vector(char *val, int num, int width, Vector &vec) override;
 
     void dump(ostream &strm) const override;
 };

--- a/XDRFileUnMarshaller.h
+++ b/XDRFileUnMarshaller.h
@@ -53,25 +53,25 @@ public:
     XDRFileUnMarshaller(FILE *out);
     virtual ~XDRFileUnMarshaller();
 
-    virtual void get_byte(dods_byte &val) override;
+    void get_byte(dods_byte &val) override;
 
-    virtual void get_int16(dods_int16 &val) override;
-    virtual void get_int32(dods_int32 &val) override;
+    void get_int16(dods_int16 &val) override;
+    void get_int32(dods_int32 &val) override;
 
-    virtual void get_float32(dods_float32 &val) override;
-    virtual void get_float64(dods_float64 &val) override;
+    void get_float32(dods_float32 &val) override;
+    void get_float64(dods_float64 &val) override;
 
-    virtual void get_uint16(dods_uint16 &val) override;
-    virtual void get_uint32(dods_uint32 &val) override;
+    void get_uint16(dods_uint16 &val) override;
+    void get_uint32(dods_uint32 &val) override;
 
-    virtual void get_str(string &val) override;
-    virtual void get_url(string &val) override;
+    void get_str(string &val) override;
+    void get_url(string &val) override;
 
-    virtual void get_opaque(char *val, unsigned int len) override;
-    virtual void get_int(int &val) override;
+    void get_opaque(char *val, unsigned int len) override;
+    void get_int(int &val) override;
 
-    virtual void get_vector(char **val, unsigned int &num, Vector &vec) override;
-    virtual void get_vector(char **val, unsigned int &num, int width, Vector &vec) override;
+    void get_vector(char **val, unsigned int &num, Vector &vec) override;
+    void get_vector(char **val, unsigned int &num, int width, Vector &vec) override;
 
     void dump(ostream &strm) const override;
 };

--- a/XDRFileUnMarshaller.h
+++ b/XDRFileUnMarshaller.h
@@ -53,27 +53,27 @@ public:
     XDRFileUnMarshaller(FILE *out);
     virtual ~XDRFileUnMarshaller();
 
-    virtual void get_byte(dods_byte &val);
+    virtual void get_byte(dods_byte &val) override;
 
-    virtual void get_int16(dods_int16 &val);
-    virtual void get_int32(dods_int32 &val);
+    virtual void get_int16(dods_int16 &val) override;
+    virtual void get_int32(dods_int32 &val) override;
 
-    virtual void get_float32(dods_float32 &val);
-    virtual void get_float64(dods_float64 &val);
+    virtual void get_float32(dods_float32 &val) override;
+    virtual void get_float64(dods_float64 &val) override;
 
-    virtual void get_uint16(dods_uint16 &val);
-    virtual void get_uint32(dods_uint32 &val);
+    virtual void get_uint16(dods_uint16 &val) override;
+    virtual void get_uint32(dods_uint32 &val) override;
 
-    virtual void get_str(string &val);
-    virtual void get_url(string &val);
+    virtual void get_str(string &val) override;
+    virtual void get_url(string &val) override;
 
-    virtual void get_opaque(char *val, unsigned int len);
-    virtual void get_int(int &val);
+    virtual void get_opaque(char *val, unsigned int len) override;
+    virtual void get_int(int &val) override;
 
-    virtual void get_vector(char **val, unsigned int &num, Vector &vec);
-    virtual void get_vector(char **val, unsigned int &num, int width, Vector &vec);
+    virtual void get_vector(char **val, unsigned int &num, Vector &vec) override;
+    virtual void get_vector(char **val, unsigned int &num, int width, Vector &vec) override;
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/XDRStreamMarshaller.h
+++ b/XDRStreamMarshaller.h
@@ -72,31 +72,31 @@ public:
     XDRStreamMarshaller(ostream &out); //, bool checksum = false, bool write_data = true) ;
     virtual ~XDRStreamMarshaller();
 
-    virtual void put_byte(dods_byte val);
+    virtual void put_byte(dods_byte val) override;
 
-    virtual void put_int16(dods_int16 val);
-    virtual void put_int32(dods_int32 val);
+    virtual void put_int16(dods_int16 val) override;
+    virtual void put_int32(dods_int32 val) override;
 
-    virtual void put_float32(dods_float32 val);
-    virtual void put_float64(dods_float64 val);
+    virtual void put_float32(dods_float32 val) override;
+    virtual void put_float64(dods_float64 val) override;
 
-    virtual void put_uint16(dods_uint16 val);
-    virtual void put_uint32(dods_uint32 val);
+    virtual void put_uint16(dods_uint16 val) override;
+    virtual void put_uint32(dods_uint32 val) override;
 
-    virtual void put_str(const string &val);
-    virtual void put_url(const string &val);
+    virtual void put_str(const string &val) override;
+    virtual void put_url(const string &val) override;
 
-    virtual void put_opaque(char *val, unsigned int len);
-    virtual void put_int(int val);
+    virtual void put_opaque(char *val, unsigned int len) override;
+    virtual void put_int(int val) override;
 
-    virtual void put_vector(char *val, int num, Vector &vec);
-    virtual void put_vector(char *val, int num, int width, Vector &vec);
+    virtual void put_vector(char *val, int num, Vector &vec) override;
+    virtual void put_vector(char *val, int num, int width, Vector &vec) override;
 
-    virtual void put_vector_start(int num);
-    virtual void put_vector_part(char *val, unsigned int num, int width, Type type);
-    virtual void put_vector_end();
+    virtual void put_vector_start(int num) override;
+    virtual void put_vector_part(char *val, unsigned int num, int width, Type type) override;
+    virtual void put_vector_end() override;
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/XDRStreamMarshaller.h
+++ b/XDRStreamMarshaller.h
@@ -72,29 +72,29 @@ public:
     XDRStreamMarshaller(ostream &out); //, bool checksum = false, bool write_data = true) ;
     virtual ~XDRStreamMarshaller();
 
-    virtual void put_byte(dods_byte val) override;
+    void put_byte(dods_byte val) override;
 
-    virtual void put_int16(dods_int16 val) override;
-    virtual void put_int32(dods_int32 val) override;
+    void put_int16(dods_int16 val) override;
+    void put_int32(dods_int32 val) override;
 
-    virtual void put_float32(dods_float32 val) override;
-    virtual void put_float64(dods_float64 val) override;
+    void put_float32(dods_float32 val) override;
+    void put_float64(dods_float64 val) override;
 
-    virtual void put_uint16(dods_uint16 val) override;
-    virtual void put_uint32(dods_uint32 val) override;
+    void put_uint16(dods_uint16 val) override;
+    void put_uint32(dods_uint32 val) override;
 
-    virtual void put_str(const string &val) override;
-    virtual void put_url(const string &val) override;
+    void put_str(const string &val) override;
+    void put_url(const string &val) override;
 
-    virtual void put_opaque(char *val, unsigned int len) override;
-    virtual void put_int(int val) override;
+    void put_opaque(char *val, unsigned int len) override;
+    void put_int(int val) override;
 
-    virtual void put_vector(char *val, int num, Vector &vec) override;
-    virtual void put_vector(char *val, int num, int width, Vector &vec) override;
+    void put_vector(char *val, int num, Vector &vec) override;
+    void put_vector(char *val, int num, int width, Vector &vec) override;
 
-    virtual void put_vector_start(int num) override;
-    virtual void put_vector_part(char *val, unsigned int num, int width, Type type) override;
-    virtual void put_vector_end() override;
+    void put_vector_start(int num) override;
+    void put_vector_part(char *val, unsigned int num, int width, Type type) override;
+    void put_vector_end() override;
 
     void dump(ostream &strm) const override;
 };

--- a/XDRStreamUnMarshaller.h
+++ b/XDRStreamUnMarshaller.h
@@ -64,25 +64,25 @@ public:
     XDRStreamUnMarshaller(istream &in);
     virtual ~XDRStreamUnMarshaller();
 
-    virtual void get_byte(dods_byte &val) override;
+    void get_byte(dods_byte &val) override;
 
-    virtual void get_int16(dods_int16 &val) override;
-    virtual void get_int32(dods_int32 &val) override;
+    void get_int16(dods_int16 &val) override;
+    void get_int32(dods_int32 &val) override;
 
-    virtual void get_float32(dods_float32 &val) override;
-    virtual void get_float64(dods_float64 &val) override;
+    void get_float32(dods_float32 &val) override;
+    void get_float64(dods_float64 &val) override;
 
-    virtual void get_uint16(dods_uint16 &val) override;
-    virtual void get_uint32(dods_uint32 &val) override;
+    void get_uint16(dods_uint16 &val) override;
+    void get_uint32(dods_uint32 &val) override;
 
-    virtual void get_str(string &val) override;
-    virtual void get_url(string &val) override;
+    void get_str(string &val) override;
+    void get_url(string &val) override;
 
-    virtual void get_opaque(char *val, unsigned int len) override;
-    virtual void get_int(int &val) override;
+    void get_opaque(char *val, unsigned int len) override;
+    void get_int(int &val) override;
 
-    virtual void get_vector(char **val, unsigned int &num, Vector &vec) override;
-    virtual void get_vector(char **val, unsigned int &num, int width, Vector &vec) override;
+    void get_vector(char **val, unsigned int &num, Vector &vec) override;
+    void get_vector(char **val, unsigned int &num, int width, Vector &vec) override;
 
     virtual void get_vector(char **val, unsigned int &num, int width, Type type);
 

--- a/XDRStreamUnMarshaller.h
+++ b/XDRStreamUnMarshaller.h
@@ -64,29 +64,29 @@ public:
     XDRStreamUnMarshaller(istream &in);
     virtual ~XDRStreamUnMarshaller();
 
-    virtual void get_byte(dods_byte &val);
+    virtual void get_byte(dods_byte &val) override;
 
-    virtual void get_int16(dods_int16 &val);
-    virtual void get_int32(dods_int32 &val);
+    virtual void get_int16(dods_int16 &val) override;
+    virtual void get_int32(dods_int32 &val) override;
 
-    virtual void get_float32(dods_float32 &val);
-    virtual void get_float64(dods_float64 &val);
+    virtual void get_float32(dods_float32 &val) override;
+    virtual void get_float64(dods_float64 &val) override;
 
-    virtual void get_uint16(dods_uint16 &val);
-    virtual void get_uint32(dods_uint32 &val);
+    virtual void get_uint16(dods_uint16 &val) override;
+    virtual void get_uint32(dods_uint32 &val) override;
 
-    virtual void get_str(string &val);
-    virtual void get_url(string &val);
+    virtual void get_str(string &val) override;
+    virtual void get_url(string &val) override;
 
-    virtual void get_opaque(char *val, unsigned int len);
-    virtual void get_int(int &val);
+    virtual void get_opaque(char *val, unsigned int len) override;
+    virtual void get_int(int &val) override;
 
-    virtual void get_vector(char **val, unsigned int &num, Vector &vec);
-    virtual void get_vector(char **val, unsigned int &num, int width, Vector &vec);
+    virtual void get_vector(char **val, unsigned int &num, Vector &vec) override;
+    virtual void get_vector(char **val, unsigned int &num, int width, Vector &vec) override;
 
     virtual void get_vector(char **val, unsigned int &num, int width, Type type);
 
-    virtual void dump(ostream &strm) const;
+    void dump(ostream &strm) const override;
 };
 
 } // namespace libdap

--- a/tidy-warnings/README.md
+++ b/tidy-warnings/README.md
@@ -189,15 +189,15 @@ if __name__ == "__main__":
 
 1. Make it executable:
 
-   ```bash
+```bash
    chmod +x apply_overrides.py
-   ```
+```
 
 2. Run it against your list:
 
-   ```bash
+```bash
    ./apply_overrides.py override_list.txt
-   ```
+```
 
 This will:
 

--- a/tidy-warnings/README.md
+++ b/tidy-warnings/README.md
@@ -1,0 +1,208 @@
+
+# Repair missing 'override' warnings
+
+## Part 1
+
+Given a but of goop from the compiler, extract files with missing 'override' keywords and get set to
+automatically edit them.
+
+Here’s a simple Python script you can drop into your PATH (or run in-place) that will scan through your CMake output file and pull out every warning of the form:
+
+```
+/path/to/File.h:LINE:COLUMN: warning: 'FUNCTION' overrides a member function but is not marked 'override'
+```
+
+and write out a tab-separated file of:
+
+```
+/full/path/to/File.h<TAB>FUNCTION
+```
+
+Save this as, say, `extract_override_warnings.py`:
+
+```python
+#!/usr/bin/env python3
+import re
+import sys
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <input_file> <output_file>", file=sys.stderr)
+        sys.exit(1)
+
+    infile, outfile = sys.argv[1], sys.argv[2]
+    # regex breakdown:
+    #   ^(.+?)         → group 1: shortest prefix up to first colon (the full path)
+    #   :\d+:\d+:      → skip :LINE:COLUMN:
+    #   \s+warning:\s+ → literal “ warning: ”
+    #   '([^']+)'      → group 2: the function name inside quotes
+    #   \s+overrides   → literal “ overrides” to anchor
+    pattern = re.compile(
+        r"^(.+?):\d+:\d+:\s+warning:\s+'([^']+)'\s+overrides.*not marked 'override'"
+    )
+
+    with open(infile, 'r') as fin, open(outfile, 'w') as fout:
+        for line in fin:
+            m = pattern.match(line)
+            if m:
+                path, func = m.group(1), m.group(2)
+                fout.write(f"{path}\t{func}\n")
+
+if __name__ == "__main__":
+    main()
+```
+
+Make it executable:
+
+```bash
+chmod +x extract_override_warnings.py
+```
+
+Then run:
+
+```bash
+./extract_override_warnings.py build_output.txt override_list.txt
+```
+
+Each line in `override_list.txt` will look like:
+
+```
+/Users/jimg/src/opendap/hyrax/libdap4/Structure.h    ptr_duplicate
+/Users/jimg/src/opendap/hyrax/libdap4/Structure.h    transform_to_dap4
+...
+```
+
+You can then feed `override_list.txt` into whatever tool you like (awk, another Python script, etc.) to automatically insert `override` or make other fixes.
+
+## PArt 2
+
+Below is a standalone Python script, `apply_overrides.py`, that:
+
+1. Reads a two-column list (`override_list.txt`) of `<header-path>\t<function_name>` (as produced by your extractor).
+2. Groups all function names by header file.
+3. For each header, makes a backup (`.bak`) and edits in-place:
+
+   * Finds every `virtual ... functionName(...)[ const];`
+   * Inserts `override` immediately before the trailing semicolon (after `const` if present).
+   * Leaves other lines untouched.
+
+```python
+#!/usr/bin/env python3
+import sys
+import re
+import shutil
+from pathlib import Path
+from collections import defaultdict
+
+def load_overrides(list_file):
+    """
+    Read the override list file of lines:
+      /path/to/File.h<TAB>functionName
+    Returns a dict: { Path: set(functionName, ...) }
+    """
+    overrides = defaultdict(set)
+    with open(list_file, 'r') as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.strip()
+            if not line or '\t' not in line:
+                continue
+            path_str, func = line.split('\t', 1)
+            path = Path(path_str)
+            overrides[path].add(func)
+    return overrides
+
+def apply_override_to_file(path, funcs):
+    """
+    For each virtual declaration of functions in `funcs`, insert 'override' before ';'.
+    Creates a backup at path.with_suffix(path.suffix + '.bak').
+    """
+    bak = path.with_suffix(path.suffix + '.bak')
+    if not bak.exists():
+        shutil.copy2(path, bak)
+        print(f"Backed up {path} → {bak}")
+    else:
+        print(f"Backup already exists: {bak}")
+
+    # Compile one regex per function for performance
+    patterns = []
+    for func in funcs:
+        # pattern explanation:
+        #   ^(?P<before>\s*virtual\b[^\n]*\bfunc\s*\([^;]*\))
+        #       captures "    virtual ... func(...)" including trailing "const" if present
+        #   (?P<const>\s+const)?    optionally capture " const"
+        #   (?P<after>\s*;)$        capture the semicolon and EOL
+        pat = re.compile(
+            rf'^(?P<before>\s*virtual\b[^\n]*\b{re.escape(func)}\s*\([^;]*?\))'
+            rf'(?P<const>\s+const)?'
+            rf'(?P<after>\s*;)\s*$'
+        )
+        patterns.append((func, pat))
+
+    # Read & rewrite
+    changed = False
+    lines = path.read_text().splitlines()
+    out_lines = []
+    for i, line in enumerate(lines, 1):
+        new_line = line
+        for func, pat in patterns:
+            m = pat.match(line)
+            if m:
+                before = m.group('before')
+                const = m.group('const') or ''
+                after = m.group('after')
+                # check if already has override
+                if 'override' not in line:
+                    new_line = f"{before}{const} override{after}"
+                    print(f"{path}:{i}: added override to `{func}`")
+                    changed = True
+                break
+        out_lines.append(new_line)
+
+    if changed:
+        path.write_text("\n".join(out_lines) + "\n")
+        print(f"Updated {path}")
+    else:
+        print(f"No changes in {path}")
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} override_list.txt", file=sys.stderr)
+        sys.exit(1)
+
+    list_file = Path(sys.argv[1])
+    if not list_file.exists():
+        print(f"Error: {list_file} not found", file=sys.stderr)
+        sys.exit(1)
+
+    overrides = load_overrides(list_file)
+    for path, funcs in overrides.items():
+        if not path.exists():
+            print(f"Warning: file not found: {path}", file=sys.stderr)
+            continue
+        apply_override_to_file(path, funcs)
+
+if __name__ == "__main__":
+    main()
+```
+
+### How to use
+
+1. Make it executable:
+
+   ```bash
+   chmod +x apply_overrides.py
+   ```
+
+2. Run it against your list:
+
+   ```bash
+   ./apply_overrides.py override_list.txt
+   ```
+
+This will:
+
+* Create a `.bak` copy of each header before editing.
+* Scan for each `virtual … functionName(...) [const];` and insert `override` if missing.
+* Report each insertion with filename and line number.
+
+You can tweak the regex if you have more complex declarations, but this should handle both plain and `const` methods, as well as multiple overloads in the same file.

--- a/tidy-warnings/apply_overrides.py
+++ b/tidy-warnings/apply_overrides.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import sys
+import re
+import shutil
+from pathlib import Path
+from collections import defaultdict
+
+def load_overrides(list_file):
+    """
+    Read the override list file of lines:
+      /path/to/File.h<TAB>functionName
+    Returns a dict: { Path: set(functionName, ...) }
+    """
+    overrides = defaultdict(set)
+    with open(list_file, 'r') as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.strip()
+            if not line or '\t' not in line:
+                continue
+            path_str, func = line.split('\t', 1)
+            path = Path(path_str)
+            overrides[path].add(func)
+    return overrides
+
+def apply_override_to_file(path, funcs):
+    """
+    For each virtual declaration of functions in `funcs`, insert 'override' before ';'.
+    Creates a backup at path.with_suffix(path.suffix + '.bak').
+    """
+    bak = path.with_suffix(path.suffix + '.bak')
+    if not bak.exists():
+        shutil.copy2(path, bak)
+        print(f"Backed up {path} → {bak}")
+    else:
+        print(f"Backup already exists: {bak}")
+
+    # Compile one regex per function for performance
+    patterns = []
+    for func in funcs:
+        # pattern explanation:
+        #   ^(?P<before>\s*virtual\b[^\n]*\bfunc\s*\([^;]*\))
+        #       captures "    virtual ... func(...)" including trailing "const" if present
+        #   (?P<const>\s+const)?    optionally capture " const"
+        #   (?P<after>\s*;)$        capture the semicolon and EOL
+        pat = re.compile(
+            rf'^(?P<before>\s*virtual\b[^\n]*\b{re.escape(func)}\s*\([^;]*?\))'
+            rf'(?P<const>\s+const)?'
+            rf'(?P<after>\s*;)\s*$'
+        )
+        patterns.append((func, pat))
+
+    # Read & rewrite
+    changed = False
+    lines = path.read_text().splitlines()
+    out_lines = []
+    for i, line in enumerate(lines, 1):
+        new_line = line
+        for func, pat in patterns:
+            m = pat.match(line)
+            if m:
+                before = m.group('before')
+                const = m.group('const') or ''
+                after = m.group('after')
+                # check if already has override
+                if 'override' not in line:
+                    new_line = f"{before}{const} override{after}"
+                    print(f"{path}:{i}: added override to `{func}`")
+                    changed = True
+                break
+        out_lines.append(new_line)
+
+    if changed:
+        path.write_text("\n".join(out_lines) + "\n")
+        print(f"Updated {path}")
+    else:
+        print(f"No changes in {path}")
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} override_list.txt", file=sys.stderr)
+        sys.exit(1)
+
+    list_file = Path(sys.argv[1])
+    if not list_file.exists():
+        print(f"Error: {list_file} not found", file=sys.stderr)
+        sys.exit(1)
+
+    overrides = load_overrides(list_file)
+    for path, funcs in overrides.items():
+        if not path.exists():
+            print(f"Warning: file not found: {path}", file=sys.stderr)
+            continue
+        apply_override_to_file(path, funcs)
+
+if __name__ == "__main__":
+    main()

--- a/tidy-warnings/extract-warnings.py
+++ b/tidy-warnings/extract-warnings.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <input_file> <output_file>", file=sys.stderr)
+        sys.exit(1)
+
+    infile, outfile = sys.argv[1], sys.argv[2]
+    # regex breakdown:
+    #   ^(.+?)         → group 1: shortest prefix up to first colon (the full path)
+    #   :\d+:\d+:      → skip :LINE:COLUMN:
+    #   \s+warning:\s+ → literal “ warning: ”
+    #   '([^']+)'      → group 2: the function name inside quotes
+    #   \s+overrides   → literal “ overrides” to anchor
+    pattern = re.compile(
+        r"^(.+?):\d+:\d+:\s+warning:\s+'([^']+)'\s+overrides.*not marked 'override'"
+    )
+
+    with open(infile, 'r') as fin, open(outfile, 'w') as fout:
+        for line in fin:
+            m = pattern.match(line)
+            if m:
+                path, func = m.group(1), m.group(2)
+                fout.write(f"{path}\t{func}\n")
+
+if __name__ == "__main__":
+    main()

--- a/tidy-warnings/remove_redundant_virtual.py
+++ b/tidy-warnings/remove_redundant_virtual.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import sys
+import shutil
+import re
+from pathlib import Path
+
+def process_file(path: Path):
+    bak = path.with_suffix(path.suffix + '.bak')
+    if not bak.exists():
+        shutil.copy2(path, bak)
+        print(f"Backed up {path} → {bak}")
+    else:
+        print(f"Backup exists: {bak}")
+
+    changed = False
+    pattern = re.compile(r'^(\s*)virtual\s+(.*\boverride\b.*)$')
+    new_lines = []
+    for lineno, line in enumerate(path.read_text().splitlines(), 1):
+        m = pattern.match(line)
+        if m:
+            indent, rest = m.groups()
+            new_line = f"{indent}{rest}"
+            if new_line != line:
+                print(f"{path}:{lineno}: removed redundant 'virtual'")
+                line = new_line
+                changed = True
+        new_lines.append(line)
+
+    if changed:
+        path.write_text("\n".join(new_lines) + "\n")
+        print(f"Updated {path}\n")
+    else:
+        print(f"No changes in {path}\n")
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file-or-dir> [<file-or-dir> ...]", file=sys.stderr)
+        sys.exit(1)
+
+    for arg in sys.argv[1:]:
+        p = Path(arg)
+        if p.is_dir():
+            for ext in ('*.h', '*.hpp'):
+                for file in p.rglob(ext):
+                    process_file(file)
+        elif p.is_file():
+            process_file(p)
+        else:
+            print(f"Warning: not found: {arg}", file=sys.stderr)
+
+if __name__ == '__main__':
+    main()

--- a/tidy-warnings/warnings_1.txt
+++ b/tidy-warnings/warnings_1.txt
@@ -1,0 +1,14 @@
+/Users/jimg/src/opendap/hyrax/libdap4/Structure.h	ptr_duplicate
+/Users/jimg/src/opendap/hyrax/libdap4/Structure.h	transform_to_dap4
+/Users/jimg/src/opendap/hyrax/libdap4/Structure.h	is_linear
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	ptr_duplicate
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	clear_local_data
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	transform_to_dap4
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	toString
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	is_linear
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	length
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	intern_data
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	serialize
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	deserialize
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	print_val
+/Users/jimg/src/opendap/hyrax/libdap4/Sequence.h	print_val


### PR DESCRIPTION
I used python to extract the warnings and then edit the headers so they say 'override' on all the
appropriate methods. I was sick of the warnings. I also fixed a warning about arrays and tun-time
length definitions. 