### PR TITLE
Add bash shell scripts that allow to setup a build system for libdap4…

### DIFF
--- a/README.cmake.dependencies.md
+++ b/README.cmake.dependencies.md
@@ -1,0 +1,211 @@
+# Build Guide for libdap dependencies 
+
+This guide provides a complete build system for libdap4 and all its dependencies from source code. 
+It includes automated scripts and detailed instructions for building on multiple platforms, with specific support for Windows.
+
+## Quick Start
+
+The build process involves compiling these dependencies in order:
+1. zlib
+2. libxml2  
+3. curl
+4. cppunit
+5. libdap4
+
+Each dependency can be built using the provided CMake scripts or the automated build scripts included in this repository.
+
+## Directory Structure
+
+```
+parent-directory/
+├── ext/                         # dependencies sources
+│   ├── cppunit-1.15.1/
+│   ├── libxml2-2.14.5/
+│   ├── curl-8.15.0/
+│   └── zlib-1.3.1/
+├── build/
+│   ├── cppunit-1.15.1/
+│   ├── libxml2-2.14.5/
+│   ├── curl-8.15.0/
+│   └── zlib-1.3.1/
+│   └── libdap4/                 # libdap build directory
+├── install/                     # all built dependencies
+│   ├── cppunit-1.15.1/
+│   ├── libxml2-2.14.5/
+│   ├── curl-8.15.0/
+│   ├── zlib-1.3.1/
+│   └── libdap4/                 # final libdap installation
+└── libdap4/                     # libdap source code
+```
+
+## Windows specific pre-build dependencies
+
+### Bison and Flex
+
+WinFlexBison - A Windows port specifically designed for Visual Studio:
+
+Download from: https://github.com/lexxmark/winflexbison
+
+### OpenSSL
+
+Official OpenSSL Binaries:
+
+Download from: https://slproweb.com/products/Win32OpenSSL.html
+
+Choose "Win64 OpenSSL v3.x.x"
+
+## 1. Build zlib 
+
+```bash
+git -c advice.detachedHead=false clone --branch v1.3.1 --depth 1 https://github.com/madler/zlib.git zlib-1.3.1
+```
+
+Build with 
+
+```bash
+mkdir -p ../build/zlib-1.3.1
+pushd ../build
+pushd zlib-1.3.1
+cmake ../../ext/zlib-1.3.1 \
+  -DCMAKE_INSTALL_PREFIX=../../install/zlib-1.3.1 \
+  -DBUILD_SHARED_LIBS=OFF 
+cmake --build . --config Debug --parallel
+cmake --install . --config Debug
+popd 
+popd
+```
+
+or use supplied script 
+
+```bash
+build.zlib.cmake.sh
+```
+
+Final directory structure is
+
+```
+../ext/zlib-1.3.1/ (source)
+../build/zlib-1.3.1/ (build)
+../install/zlib-1.3.1/ (install)
+```
+
+## 2. Build libxml2
+
+```bash
+git -c advice.detachedHead=false clone --branch v2.14.5 --depth 1 https://github.com/GNOME/libxml2.git libxml2-2.14.5
+```
+
+Build with 
+
+```bash
+mkdir -p ../build/libxml2-2.14.5
+pushd ../build
+pushd libxml2-2.14.5
+cmake ../../ext/libxml2-2.14.5 \
+  -DCMAKE_INSTALL_PREFIX=../../install/libxml2-2.14.5 \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DLIBXML2_WITH_ICONV=OFF \
+  -DLIBXML2_WITH_LZMA=OFF \
+  -DLIBXML2_WITH_PYTHON=OFF \
+  -DLIBXML2_WITH_ZLIB=ON \
+  -DZLIB_ROOT=../../install/zlib-1.3.1 \
+  --fresh
+cmake --build . --config Debug --parallel
+cmake --install . --config Debug
+popd 
+popd
+```
+
+or use supplied script 
+
+```bash
+build.libxml2.cmake.sh
+```
+
+## 3. Build curl
+
+```bash
+git -c advice.detachedHead=false clone --branch curl-8_15_0 --depth 1 https://github.com/curl/curl.git curl-8.15.0
+```
+
+Build with 
+
+```bash
+mkdir -p ../build/curl-8.15.0
+pushd ../build
+pushd curl-8.15.0
+cmake ../../ext/curl-8.15.0 \
+  -DCMAKE_INSTALL_PREFIX=../../install/curl-8.15.0 \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCURL_USE_LIBPSL=OFF \
+  -DCURL_USE_OPENSSL=ON \
+  -DZLIB_ROOT=../../install/zlib-1.3.1 \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DBUILD_CURL_EXE=OFF \
+  -DBUILD_TESTING=OFF \
+  --fresh
+cmake --build . --config Debug --parallel
+cmake --install . --config Debug
+popd 
+popd
+```
+
+or use supplied script 
+
+```bash
+build.curl.cmake.sh
+```
+
+## 4. Build CppUnit
+
+```bash
+git -c advice.detachedHead=false clone --branch 1.15.1 --depth 1 https://anongit.freedesktop.org/git/libreoffice/cppunit.git cppunit-1.15.1
+```
+
+**Important Note: Unfortunately, CMake is not part of original cppunit distribution. So, we create one using the supplied bash shell script**
+
+```bash
+build.cppunit.cmake.sh
+```
+
+Build with 
+
+```bash
+mkdir -p ../build/cppunit-1.15.1
+pushd ../build
+pushd cppunit-1.15.1
+cmake ../../ext/cppunit-1.15.1 \
+  -DCMAKE_INSTALL_PREFIX=../../install/cppunit-1.15.1 \
+  -DCPPUNIT_BUILD_SHARED_LIBS=OFF \
+  --fresh
+cmake --build . --config Debug --parallel
+cmake --install . --config Debug
+popd 
+popd
+```
+
+## 5. Build libdap4
+
+Finnally (!), build libdap4with 
+
+```bash
+make ../../libdap4 \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_INSTALL_PREFIX="../../install/libdap4" \
+  -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
+  -DLibXml2_ROOT="../../install/libxml2-2.14.5" \
+  -DLIBXML2_LIBRARY="$LIBXML2_LIB_PATH" \
+  -DUSE_ASAN=ON \
+  -DBUILD_DEVELOPER=ON \
+  --fresh
+```
+
+Note: $LIBXML2_LIB_PATH is system dependent, see supplied script 
+
+```bash
+build.libdap.cmake.sh
+```
+
+
+

--- a/build.cppunit.cmake.sh
+++ b/build.cppunit.cmake.sh
@@ -1,0 +1,405 @@
+#!/bin/bash
+
+# check if ../ext/cppunit-1.15.1 directory exists, if not try different approaches based on platform
+if [ ! -d "../ext/cppunit-1.15.1" ]; then
+    echo "cppunit-1.15.1 not found in ../ext/"
+    
+    # Check platform - use system packages for Linux and macOS, build from source for Windows
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "Detected Linux system - checking for system cppunit package..."
+        
+        # Check if system has cppunit development packages
+        if pkg-config --exists cppunit 2>/dev/null; then
+            echo "Found system cppunit package, creating symlink..."
+            mkdir -p ../ext
+            mkdir -p ../ext/cppunit-1.15.1
+            
+            # Create a minimal structure pointing to system cppunit
+            CPPUNIT_INCLUDE=$(pkg-config --variable=includedir cppunit)
+            CPPUNIT_LIB=$(pkg-config --variable=libdir cppunit)
+            
+            echo "System cppunit found at:"
+            echo "  Include: $CPPUNIT_INCLUDE"
+            echo "  Lib: $CPPUNIT_LIB"
+            echo "Skipping build - will use system version"
+            
+            # Create marker file
+            touch ../ext/cppunit-1.15.1/.system_package
+        else
+            echo "ERROR: No system cppunit found. Please install it:"
+            echo "  Ubuntu/Debian: sudo apt-get install libcppunit-dev"
+            echo "  CentOS/RHEL: sudo yum install cppunit-devel"
+            echo "  Fedora: sudo dnf install cppunit-devel"
+            echo "Then run this script again."
+            exit 1
+        fi
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "Detected macOS system - checking for Homebrew cppunit..."
+        
+        # Check for Homebrew installation of cppunit
+        if command -v brew >/dev/null 2>&1 && brew list cppunit >/dev/null 2>&1; then
+            echo "Found Homebrew cppunit package, creating symlink..."
+            mkdir -p ../ext
+            mkdir -p ../ext/cppunit-1.15.1
+            
+            # Get Homebrew prefix and cppunit paths
+            BREW_PREFIX=$(brew --prefix)
+            CPPUNIT_INCLUDE="$BREW_PREFIX/include"
+            CPPUNIT_LIB="$BREW_PREFIX/lib"
+            
+            echo "Homebrew cppunit found at:"
+            echo "  Include: $CPPUNIT_INCLUDE"
+            echo "  Lib: $CPPUNIT_LIB"
+            echo "Skipping build - will use Homebrew version"
+            
+            # Create marker file
+            touch ../ext/cppunit-1.15.1/.system_package
+        else
+            echo "ERROR: No Homebrew cppunit found. Please install it:"
+            if ! command -v brew >/dev/null 2>&1; then
+                echo "  First install Homebrew: https://brew.sh"
+            fi
+            echo "  Then install cppunit: brew install cppunit"
+            echo "Then run this script again."
+            exit 1
+        fi
+    else
+        # Windows or other platforms - build from source
+        echo "Detected Windows/other system - building from source..."
+        mkdir -p ../ext
+        pushd ../ext
+        
+        git -c advice.detachedHead=false clone --depth 1 https://anongit.freedesktop.org/git/libreoffice/cppunit.git cppunit-1.15.1
+        if [ $? -ne 0 ]; then
+            echo "Failed to clone cppunit repository"
+            exit 1
+        fi
+        popd
+    fi
+else
+    echo "cppunit-1.15.1 already exists in ../ext/"
+fi
+
+# Check if using system package (Linux and macOS)
+if [ -f "../ext/cppunit-1.15.1/.system_package" ]; then
+    echo "Using system cppunit package - no build needed"
+    
+    # Create install directory structure for compatibility
+    mkdir -p ../install/cppunit-1.15.1/include
+    mkdir -p ../install/cppunit-1.15.1/lib
+    
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        # Linux: use pkg-config
+        CPPUNIT_INCLUDE=$(pkg-config --variable=includedir cppunit)
+        CPPUNIT_LIB=$(pkg-config --variable=libdir cppunit)
+    else
+        # macOS: use Homebrew paths
+        BREW_PREFIX=$(brew --prefix)
+        CPPUNIT_INCLUDE="$BREW_PREFIX/include"
+        CPPUNIT_LIB="$BREW_PREFIX/lib"
+    fi
+    
+    # Create symlinks to system installation
+    if [ -d "$CPPUNIT_INCLUDE/cppunit" ]; then
+        ln -sf "$CPPUNIT_INCLUDE/cppunit" ../install/cppunit-1.15.1/include/cppunit
+    fi
+    
+    # Find the library file
+    if [ -f "$CPPUNIT_LIB/libcppunit.so" ]; then
+        ln -sf "$CPPUNIT_LIB/libcppunit.so" ../install/cppunit-1.15.1/lib/libcppunit.so
+    elif [ -f "$CPPUNIT_LIB/libcppunit.a" ]; then
+        ln -sf "$CPPUNIT_LIB/libcppunit.a" ../install/cppunit-1.15.1/lib/libcppunit.a
+    elif [ -f "$CPPUNIT_LIB/libcppunit.dylib" ]; then
+        ln -sf "$CPPUNIT_LIB/libcppunit.dylib" ../install/cppunit-1.15.1/lib/libcppunit.dylib
+    fi
+    
+    echo "System cppunit setup complete"
+    exit 0
+fi
+
+# Only proceed with CMakeLists.txt creation for Windows (not Linux/macOS)
+if [[ "$OSTYPE" != "linux-gnu"* ]] && [[ "$OSTYPE" != "darwin"* ]]; then
+
+# check if CMakeLists.txt exists in cppunit, if not create it
+if [ ! -f "../ext/cppunit-1.15.1/CMakeLists.txt" ]; then
+    echo "Creating CMakeLists.txt for cppunit-1.15.1..."
+    cat > "../ext/cppunit-1.15.1/CMakeLists.txt" << 'EOF'
+cmake_minimum_required(VERSION 3.10)
+project(cppunit VERSION 1.15.1)
+
+# Options
+option(CPPUNIT_BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(CPPUNIT_BUILD_TESTS "Build tests" OFF)
+
+# Set library type
+if(CPPUNIT_BUILD_SHARED_LIBS)
+    set(CPPUNIT_LIBRARY_TYPE SHARED)
+else()
+    set(CPPUNIT_LIBRARY_TYPE STATIC)
+endif()
+
+# Include directories
+include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_BINARY_DIR}/include
+)
+
+# Configure header - create config directory if needed
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/config)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/cppunit)
+
+# Create config-auto.h (the missing header file)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/include/cppunit/config-auto.h
+"#ifndef CPPUNIT_CONFIG_AUTO_H
+#define CPPUNIT_CONFIG_AUTO_H
+
+#include <typeinfo>
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define CPPUNIT_HAVE_DLFCN_H 1
+
+/* define if library exports are declared as dll export under win32 */
+#ifdef _WIN32
+#define CPPUNIT_BUILD_DLL 1
+#endif
+
+/* Define to 1 if you have the `finite' function. */
+#define CPPUNIT_HAVE_FINITE 1
+
+/* define if the library defines strstream */
+#define CPPUNIT_HAVE_CLASS_STRSTREAM 0
+
+/* Define if you have the GNU dld library. */
+/* #undef CPPUNIT_HAVE_DLD */
+
+/* Define to 1 if you have the `dlerror' function. */
+#define CPPUNIT_HAVE_DLERROR 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define CPPUNIT_HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the `dlopen' function. */
+#define CPPUNIT_HAVE_DLOPEN 1
+
+/* define if the library defines std::isfinite */
+#define CPPUNIT_HAVE_ISFINITE 1
+
+/* Define if you have the libdl library or equivalent. */
+#define CPPUNIT_HAVE_LIBDL 1
+
+/* Define to 1 if you have the `m' library (-lm). */
+#define CPPUNIT_HAVE_LIBM 1
+
+/* Define if you have the shl_load function. */
+/* #undef CPPUNIT_HAVE_SHL_LOAD */
+
+/* define if the library defines sstream */
+#define CPPUNIT_HAVE_SSTREAM 1
+
+/* Define to 1 if you have the <strstream> header file. */
+#define CPPUNIT_HAVE_STRSTREAM 0
+
+/* Name of package */
+#define CPPUNIT_PACKAGE \"cppunit\"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define CPPUNIT_PACKAGE_BUGREPORT \"\"
+
+/* Define to the full name of this package. */
+#define CPPUNIT_PACKAGE_NAME \"cppunit\"
+
+/* Define to the full name and version of this package. */
+#define CPPUNIT_PACKAGE_STRING \"cppunit 1.15.1\"
+
+/* Define to the one symbol short name of this package. */
+#define CPPUNIT_PACKAGE_TARNAME \"cppunit\"
+
+/* Define to the version of this package. */
+#define CPPUNIT_PACKAGE_VERSION \"1.15.1\"
+
+/* Version number of package */
+#define CPPUNIT_VERSION \"1.15.1\"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define CPPUNIT_STDC_HEADERS 1
+
+#endif /* CPPUNIT_CONFIG_AUTO_H */
+")
+
+# Create config.h.cmake
+file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/config/config.h.cmake
+"#ifndef CPPUNIT_CONFIG_H
+#define CPPUNIT_CONFIG_H
+
+#include \"cppunit/config-auto.h\"
+
+#define CPPUNIT_HAVE_SSTREAM 1
+#define CPPUNIT_HAVE_STRSTREAM 0
+#define CPPUNIT_HAVE_CLASS_STRSTREAM 0
+#define CPPUNIT_HAVE_FINITE 1
+#define CPPUNIT_HAVE_DLFCN_H 1
+
+#ifdef _WIN32
+#  define CPPUNIT_DLL_BUILD
+#endif
+
+#endif
+")
+
+# Configure header
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/config/config.h.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/include/cppunit/config.h
+)
+
+# Source files - exclude Windows-specific files on non-Windows platforms
+file(GLOB_RECURSE CPPUNIT_SOURCES
+    "src/cppunit/*.cpp"
+)
+
+# Remove Windows-specific files on non-Windows platforms
+if(NOT WIN32)
+    list(FILTER CPPUNIT_SOURCES EXCLUDE REGEX ".*DllMain\\.cpp$")
+    list(FILTER CPPUNIT_SOURCES EXCLUDE REGEX ".*Win32.*")
+    list(FILTER CPPUNIT_SOURCES EXCLUDE REGEX ".*windows.*")
+endif()
+
+# Create the library - use 'cppunit' name (lowercase) to match FindCppUnit expectations
+add_library(cppunit ${CPPUNIT_LIBRARY_TYPE} ${CPPUNIT_SOURCES})
+
+# Set compiler flags to handle compatibility issues
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(cppunit PRIVATE 
+        -fpermissive 
+        -Wno-error
+        -Wno-deprecated-declarations
+        -std=c++14
+        -DCPPUNIT_NO_TESTPLUGIN
+        -ftemplate-backtrace-limit=0
+    )
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    target_compile_options(cppunit PRIVATE 
+        -Wno-error
+        -Wno-deprecated-declarations
+        -std=c++14
+        -Wno-unqualified-std-cast-call
+        -Wno-deprecated-builtins
+        -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES=1
+    )
+endif()
+
+# Add preprocessor definitions to help with compatibility
+target_compile_definitions(cppunit PRIVATE
+    CPPUNIT_NO_TESTPLUGIN=1
+    _GLIBCXX_USE_CXX11_ABI=0
+    _LIBCPP_ENABLE_CXX17_REMOVED_FEATURES=1
+)
+
+# Set C++ standard to C++14 which has better compatibility
+set_target_properties(cppunit PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION 1
+    OUTPUT_NAME "cppunit"
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)
+
+# Include directories for the target
+target_include_directories(cppunit
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+# Install targets
+install(TARGETS cppunit
+    EXPORT cppunitTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+# Install headers
+install(DIRECTORY include/cppunit
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.h"
+)
+
+# Install generated config headers
+install(FILES 
+    ${CMAKE_CURRENT_BINARY_DIR}/include/cppunit/config.h
+    ${CMAKE_CURRENT_BINARY_DIR}/include/cppunit/config-auto.h
+    DESTINATION include/cppunit
+)
+
+# Create a traditional FindCppUnit.cmake compatible setup
+# Install a cppunit-config.cmake file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cppunit-config.cmake
+"# CppUnit Config File
+get_filename_component(CPPUNIT_CMAKE_DIR \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)
+set(CPPUNIT_INCLUDE_DIRS \"\${CPPUNIT_CMAKE_DIR}/../../include\")
+set(CPPUNIT_INCLUDE_DIR \"\${CPPUNIT_INCLUDE_DIRS}\")
+set(CPPUNIT_LIBRARIES cppunit)
+set(CPPUNIT_LIBRARY cppunit)
+set(CPPUNIT_FOUND TRUE)
+
+if(NOT TARGET cppunit)
+    include(\"\${CPPUNIT_CMAKE_DIR}/cppunitTargets.cmake\")
+endif()
+")
+
+# Export targets
+install(EXPORT cppunitTargets
+    FILE cppunitTargets.cmake
+    NAMESPACE cppunit::
+    DESTINATION lib/cmake/cppunit
+)
+
+# Install config file
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cppunit-config.cmake
+    DESTINATION lib/cmake/cppunit
+)
+
+# Also install pkg-config file for traditional builds
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cppunit.pc
+"prefix=${CMAKE_INSTALL_PREFIX}
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: cppunit
+Description: C++ unit testing framework
+Version: ${PROJECT_VERSION}
+Libs: -L\${libdir} -lcppunit
+Cflags: -I\${includedir}
+")
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cppunit.pc
+    DESTINATION lib/pkgconfig
+)
+EOF
+else
+    echo "CMakeLists.txt already exists in cppunit-1.15.1"
+fi
+
+fi  # End of Windows platforms check
+
+# build cppunit (only for Windows, not Linux/macOS)
+if [[ "$OSTYPE" != "linux-gnu"* ]] && [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "Building cppunit from source..."
+    mkdir -p ../build/cppunit-1.15.1
+    pushd ../build
+    pushd cppunit-1.15.1
+    cmake ../../ext/cppunit-1.15.1 \
+      -DCMAKE_INSTALL_PREFIX=../../install/cppunit-1.15.1 \
+      -DCPPUNIT_BUILD_SHARED_LIBS=OFF \
+      --fresh
+    cmake --build . --config Debug --parallel
+    cmake --install . --config Debug
+    popd 
+    popd
+else
+    echo "Skipping cppunit build - using system package"
+fi

--- a/build.curl.cmake.sh
+++ b/build.curl.cmake.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# check if ../ext/curl-8.15.0 directory exists, if not clone it
+if [ ! -d "../ext/curl-8.15.0" ]; then
+    echo "curl-8.15.0 not found in ../ext/, cloning from GitHub..."
+    mkdir -p ../ext
+    pushd ../ext
+    git -c advice.detachedHead=false clone --branch curl-8_15_0 --depth 1 https://github.com/curl/curl.git curl-8.15.0
+    if [ $? -ne 0 ]; then
+        echo "Failed to clone curl repository"
+        exit 1
+    fi
+    popd
+else
+    echo "curl-8.15.0 already exists in ../ext/"
+fi
+
+# build curl
+mkdir -p ../build/curl-8.15.0
+pushd ../build
+pushd curl-8.15.0
+cmake ../../ext/curl-8.15.0 \
+  -DCMAKE_INSTALL_PREFIX=../../install/curl-8.15.0 \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCURL_USE_LIBPSL=OFF \
+  -DCURL_USE_OPENSSL=ON \
+  -DZLIB_ROOT=../../install/zlib-1.3.1 \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DBUILD_CURL_EXE=OFF \
+  -DBUILD_TESTING=OFF \
+  --fresh
+cmake --build . --config Debug --parallel
+cmake --install . --config Debug
+popd 
+popd

--- a/build.dependencies.cmake.sh
+++ b/build.dependencies.cmake.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+echo "==========================================="
+echo "Building all libdap4 dependencies"
+echo "==========================================="
+
+# Exit on any error
+set -e
+
+# Make sure we're in the libdap4-3.21.1 directory
+if [ ! -f "README.cmake.dependencies.md" ]; then
+    echo "Error: This script must be run from the libdap4-3.21.1 directory"
+    echo "Current directory: $(pwd)"
+    exit 1
+fi
+
+# Make all scripts executable
+echo "-- Making build scripts executable..."
+chmod +x build.zlib.cmake.sh
+chmod +x build.libxml2.cmake.sh
+chmod +x build.curl.cmake.sh
+chmod +x build.cppunit.cmake.sh
+chmod +x build.libdap.cmake.sh
+
+echo ""
+echo "==========================================="
+echo "Step 1/5: Building zlib"
+echo "==========================================="
+./build.zlib.cmake.sh
+
+echo ""
+echo "==========================================="
+echo "Step 2/5: Building libxml2"
+echo "==========================================="
+./build.libxml2.cmake.sh
+
+echo ""
+echo "==========================================="
+echo "Step 3/5: Building curl"
+echo "==========================================="
+./build.curl.cmake.sh
+
+echo ""
+echo "==========================================="
+echo "Step 4/5: Building cppunit"
+echo "==========================================="
+./build.cppunit.cmake.sh
+
+echo ""
+echo "==========================================="
+echo "Step 5/5: Building libdap4"
+echo "==========================================="
+./build.libdap.cmake.sh
+
+echo ""
+echo "==========================================="
+echo "Build complete!"
+echo "==========================================="
+echo "All dependencies and libdap4 have been built successfully."
+echo ""
+echo "Installation directories:"
+echo "  - zlib:     ../install/zlib-1.3.1/"
+echo "  - libxml2:  ../install/libxml2-2.14.5/"
+echo "  - curl:     ../install/curl-8.15.0/"
+echo "  - cppunit:  ../install/cppunit-1.15.1/"
+echo "  - libdap4:  ../install/libdap4-3.21.1/"
+echo ""
+echo "To use libdap4 in your projects, set:"
+echo "  CMAKE_PREFIX_PATH=../install/libdap4-3.21.1"

--- a/build.libdap.cmake.sh
+++ b/build.libdap.cmake.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+echo "-- Checking dependency installations..."
+
+echo "-- Checking zlib installation..."
+find ../install/zlib-1.3.1/ -name "*.lib" -o -name "*.a" -o -name "zlib.h"
+
+echo "-- Checking LibXml2 installation..."
+find ../install/libxml2-2.14.5/ -name "*.lib" -o -name "*.a" -o -name "xmlwriter.h"
+
+echo "-- Checking curl installation..."
+find ../install/curl-8.15.0/ -name "*.lib" -o -name "*.a" -o -name "curl.h"
+
+echo "-- Checking cppunit installation..."
+find ../install/cppunit-1.15.1/ -name "*.lib" -o -name "*.a" -o -name "TestCase.h"
+
+# build directory 
+rm -rf ../build/libdap4
+mkdir -p ../build/libdap4
+pushd ../build
+pushd libdap4
+
+# set the prefix path to include all dependency installation directories
+CMAKE_PREFIX_PATH="../install/cppunit-1.15.1;../install/libxml2-2.14.5;../install/curl-8.15.0;../install/zlib-1.3.1"
+
+# detect platform and set appropriate library paths
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+    # Windows
+    echo "-- Detected Windows system, using .lib libraries"
+    LIBXML2_LIB_PATH="../install/libxml2-2.14.5/lib/libxml2sd.lib"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    echo "-- Detected macOS system, using .a libraries"
+    LIBXML2_LIB_PATH="../install/libxml2-2.14.5/lib/libxml2.a"
+else
+    # Linux and other Unix-like systems
+    echo "-- Detected Linux/Unix system, using .a libraries"
+    LIBXML2_LIB_PATH="../install/libxml2-2.14.5/lib/libxml2.a"
+fi
+
+cmake ../../libdap4 \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_INSTALL_PREFIX="../../install/libdap4" \
+  -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
+  -DLibXml2_ROOT="../install/libxml2-2.14.5" \
+  -DLIBXML2_LIBRARY="$LIBXML2_LIB_PATH" \
+  -DUSE_ASAN=ON \
+  -DBUILD_DEVELOPER=ON \
+  --fresh
+  
+echo "Press any key to continue..."
+read -n 1 -s
+
+cmake --build . --config Debug --verbose
+
+echo "Press any key to continue..."
+read -n 1 -s
+
+cmake --install . --config Debug
+popd 
+popd

--- a/build.libxml2.cmake.sh
+++ b/build.libxml2.cmake.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# check if ../ext/libxml2-2.14.5 directory exists, if not clone it
+if [ ! -d "../ext/libxml2-2.14.5" ]; then
+    echo "libxml2-2.14.5 not found in ../ext/, cloning from GitHub..."
+    mkdir -p ../ext
+    pushd ../ext
+    git -c advice.detachedHead=false clone --branch v2.14.5 --depth 1 https://github.com/GNOME/libxml2.git libxml2-2.14.5
+    if [ $? -ne 0 ]; then
+        echo "Failed to clone libxml2 repository"
+        exit 1
+    fi
+    popd
+else
+    echo "libxml2-2.14.5 already exists in ../ext/"
+fi
+
+# build libxml2
+mkdir -p ../build/libxml2-2.14.5
+pushd ../build
+pushd libxml2-2.14.5
+cmake ../../ext/libxml2-2.14.5 \
+  -DCMAKE_INSTALL_PREFIX=../../install/libxml2-2.14.5 \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DLIBXML2_WITH_ICONV=OFF \
+  -DLIBXML2_WITH_LZMA=OFF \
+  -DLIBXML2_WITH_PYTHON=OFF \
+  -DLIBXML2_WITH_ZLIB=ON \
+  -DZLIB_ROOT=../../install/zlib-1.3.1 \
+  --fresh
+cmake --build . --config Debug --parallel
+cmake --install . --config Debug
+popd 
+popd

--- a/build.zlib.cmake.sh
+++ b/build.zlib.cmake.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# check if ../ext/zlib-1.3.1 directory exists, if not clone it
+if [ ! -d "../ext/zlib-1.3.1" ]; then
+    echo "zlib-1.3.1 not found in ../ext/, cloning from GitHub..."
+    mkdir -p ../ext
+    pushd ../ext
+    git -c advice.detachedHead=false clone --branch v1.3.1 --depth 1 https://github.com/madler/zlib.git zlib-1.3.1
+    if [ $? -ne 0 ]; then
+        echo "Failed to clone zlib repository"
+        exit 1
+    fi
+    popd
+else
+    echo "zlib-1.3.1 already exists in ../ext/"
+fi
+
+# build zlib
+mkdir -p ../build/zlib-1.3.1
+pushd ../build
+pushd zlib-1.3.1
+cmake ../../ext/zlib-1.3.1 \
+  -DCMAKE_INSTALL_PREFIX=../../install/zlib-1.3.1 \
+  -DBUILD_SHARED_LIBS=OFF 
+cmake --build . --config Debug --parallel
+cmake --install . --config Debug
+popd 
+popd


### PR DESCRIPTION
Add bash shell scripts that allow to setup a build system for libdap4 and all its dependencies from source code.

It includes automated scripts and detailed instructions for building on multiple platforms, with specific support for Windows.

The build process involves compiling these dependencies in order:
1. zlib
2. libxml2
3. curl
4. cppunit
5. libdap4

Tested on Windows with Visual Studio 2022, Linux Ubuntu and Mac OS

see README.cmake.dependencies.md for details