### PR TITLE
Fix cppunit search by configure

### DIFF
--- a/conf/cppunit.m4
+++ b/conf/cppunit.m4
@@ -27,16 +27,20 @@ AC_ARG_WITH(cppunit-exec-prefix,[  --with-cppunit-exec-prefix=PFX  Exec prefix w
 
   AC_MSG_CHECKING(for Cppunit - version >= $cppunit_version_min)
   no_cppunit=""
-  if test "$CPPUNIT_CONFIG" = "no" ; then
-    CPPUNIT_CFLAGS=`pkg-config cppunit --cflags`
-    CPPUNIT_LIBS=`pkg-config cppunit --libs`
-    cppunit_version=`pkg-config cppunit --modversion`
+  cppunit_version=
+  if test "$CPPUNIT_CONFIG" = "no"; then
+    CPPUNIT_CFLAGS=`pkg-config cppunit --cflags --silence-errors`
+    CPPUNIT_LIBS=`pkg-config cppunit --libs --silence-errors`
+    cppunit_version=`pkg-config cppunit --modversion --silence-errors`
   else
     CPPUNIT_CFLAGS=`$CPPUNIT_CONFIG --cflags`
     CPPUNIT_LIBS=`$CPPUNIT_CONFIG --libs`
     cppunit_version=`$CPPUNIT_CONFIG --version`
   fi
 
+  cppunit_version_proper=0
+
+  if test -n "$cppunit_version"; then
     cppunit_major_version=`echo $cppunit_version | \
            sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`
     cppunit_minor_version=`echo $cppunit_version | \
@@ -69,6 +73,7 @@ AC_ARG_WITH(cppunit-exec-prefix,[  --with-cppunit-exec-prefix=PFX  Exec prefix w
         $cppunit_major_version \= $cppunit_major_min \& \
         $cppunit_minor_version \= $cppunit_minor_min \& \
         $cppunit_micro_version \>= $cppunit_micro_min `
+  fi
 
     if test "$cppunit_version_proper" = "1" ; then
       AC_MSG_RESULT([$cppunit_major_version.$cppunit_minor_version.$cppunit_micro_version])

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ dnl people building the source, it's not customary to supply a build number (i.e
 dnl if you're building the code for your own use, a build number seems like overkill).
 dnl jhrg 3/16/21
 AC_ARG_WITH([build],
-            [AS_HELP_STRING([--with-build=<number>],[Inject the integer build number (default is to not define a build number)])],
+            [AS_HELP_STRING([--with-build=<number><],[Inject the integer build number (default is to not define a build number)])],
             [build_number=${withval}], [build_number=])
 
 dnl If a build number is given and valid (it must be an integer), use it. If it's
@@ -66,12 +66,12 @@ dnl AC_SUBST(DAP2_DDX)
 dnl AC_DEFINE(DAP3_2_DDX, 1, [Build the DAP 3.2 version of the DDX])
 dnl AC_SUBST(DAP3_2_DDX)
 
-AS_IF([echo $PACKAGE_VERSION | grep '^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)-\([[0-9]]*\)$'],
+AS_IF([echo $PACKAGE_VERSION | grep -q '^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)-\([[0-9]]*\)$'],
       [PACKAGE_MAJOR_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)-\([[0-9]]*\)$@\1@'`
        PACKAGE_MINOR_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)-\([[0-9]]*\)$@\2@'`
        PACKAGE_PATCH_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)-\([[0-9]]*\)$@\3@'`
        PACKAGE_BUILD_NUMBER=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)-\([[0-9]]*\)$@\4@'`],
-      [AS_IF([echo $PACKAGE_VERSION | grep '^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$'],
+      [AS_IF([echo $PACKAGE_VERSION | grep -q '^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$'],
        [PACKAGE_MAJOR_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$@\1@'`
         PACKAGE_MINOR_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$@\2@'`
         PACKAGE_PATCH_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$@\3@'`
@@ -476,14 +476,19 @@ AC_CHECK_LIB([crypto], [OpenSSL_add_all_algorithms],
 	[CRYPTO_LIBS=""])
 AC_SUBST([CRYPTO_LIBS])
 
+# AM_PATH_CPPUNIT(1.12.0,
+# 	[AM_CONDITIONAL([CPPUNIT], [true])],
+#	[
+#	    PKG_CHECK_MODULES(CPPUNIT, [cppunit >= 1.12.0],
+#		[AM_CONDITIONAL([CPPUNIT], [true])],
+#		[AM_CONDITIONAL([CPPUNIT], [false])]
+#	    )
+#	]
+# )
+
 AM_PATH_CPPUNIT(1.12.0,
 	[AM_CONDITIONAL([CPPUNIT], [true])],
-	[
-	    PKG_CHECK_MODULES(CPPUNIT, [cppunit >= 1.12.0],
-		[AM_CONDITIONAL([CPPUNIT], [true])],
-		[AM_CONDITIONAL([CPPUNIT], [false])]
-	    )
-	]
+	[AM_CONDITIONAL([CPPUNIT], [false])]
 )
 
 DODS_DEBUG_OPTION


### PR DESCRIPTION
HYRAX-1960

This PR has a modification to libdap configure script that fixes how it looks for CPPUNIT. Before, it worked OK when CPPUNIT present (but there were then issues building with 1.15.1) but failed (shell error) when CPPUNIT was not present.

I verified that it now works in both cases without any error messages.