### PR TITLE
Fixed minor errors in run_tests_cppunit.h

### DIFF
--- a/unit-tests/DmrRoundTripTest.cc
+++ b/unit-tests/DmrRoundTripTest.cc
@@ -24,9 +24,6 @@
 
 #include "config.h"
 
-#include <cppunit/TextTestRunner.h>
-#include <cppunit/extensions/HelperMacros.h>
-
 #include <sstream>
 
 #include "Array.h"
@@ -44,23 +41,6 @@
 #include "run_tests_cppunit.h"
 #include "testFile.h"
 #include "test_config.h"
-
-static bool debug2 = false;
-
-#undef DBG
-#define DBG(x)                                                                                                         \
-    do {                                                                                                               \
-        if (debug) {                                                                                                   \
-            x;                                                                                                         \
-        }                                                                                                              \
-    } while (false)
-#undef DBG2
-#define DBG2(x)                                                                                                        \
-    do {                                                                                                               \
-        if (debug2) {                                                                                                  \
-            x;                                                                                                         \
-        }                                                                                                              \
-    } while (false)
 
 using namespace CppUnit;
 using namespace std;

--- a/unit-tests/run_tests_cppunit.h
+++ b/unit-tests/run_tests_cppunit.h
@@ -43,13 +43,20 @@
 bool debug = false;
 
 #undef DBG
-#define DBG(x) do { if (debug) (x); } while (false)
+#define DBG(x)                                                                                                         \
+    do {                                                                                                               \
+        if (debug)                                                                                                     \
+            x;                                                                                                         \
+    } while (false)
 
 bool debug2 = false;
 
 #undef DBG2
-#define DBG2(x) do { if (debug2) (x); } while (false)
-
+#define DBG2(x)                                                                                                        \
+    do {                                                                                                               \
+        if (debug2)                                                                                                    \
+            x;                                                                                                         \
+    } while (false)
 
 /**
  * @brief Run the test(s)


### PR DESCRIPTION
A very minor fix to run_test_cppunit.h. That header did not set 'debug2' when the -D (as opposed to -d) was used.