### PR TITLE
HYRAX-2149, add the error message when a DAP4 dimension cannot be fou…

### DIFF
--- a/d4_ce/D4ConstraintEvaluator.cc
+++ b/d4_ce/D4ConstraintEvaluator.cc
@@ -311,6 +311,10 @@ void D4ConstraintEvaluator::use_explicit_projection(Array *a, const Array::Dim_i
 D4Dimension *D4ConstraintEvaluator::slice_dimension(const std::string &id, const index &i) {
     D4Dimension *dim = dmr()->root()->find_dim(id);
 
+    if(!dim) {
+        throw Error(malformed_expr,
+                    "The dimension name '" + id + "' cannot be found");
+    }
     if ((uint64_t)i.stride > dim->size())
         throw Error(malformed_expr,
                     "For '" + id + "', the index stride value is greater than the size of the dimension");

--- a/d4_ce/D4ConstraintEvaluator.cc
+++ b/d4_ce/D4ConstraintEvaluator.cc
@@ -312,8 +312,7 @@ D4Dimension *D4ConstraintEvaluator::slice_dimension(const std::string &id, const
     D4Dimension *dim = dmr()->root()->find_dim(id);
 
     if(!dim) {
-        throw Error(malformed_expr,
-                    "The dimension name '" + id + "' cannot be found");
+        throw Error(malformed_expr, "The dimension name '" + id + "' cannot be found");
     }
     if ((uint64_t)i.stride > dim->size())
         throw Error(malformed_expr,

--- a/d4_ce/D4ConstraintEvaluator.cc
+++ b/d4_ce/D4ConstraintEvaluator.cc
@@ -311,7 +311,7 @@ void D4ConstraintEvaluator::use_explicit_projection(Array *a, const Array::Dim_i
 D4Dimension *D4ConstraintEvaluator::slice_dimension(const std::string &id, const index &i) {
     D4Dimension *dim = dmr()->root()->find_dim(id);
 
-    if(!dim) {
+    if (!dim) {
         throw Error(malformed_expr, "The dimension name '" + id + "' cannot be found");
     }
     if ((uint64_t)i.stride > dim->size())


### PR DESCRIPTION
…nd in a DAP4 expression constraint. Previously a segmentation fault occurs. Verify with an example and it returns the expected output.