### PR TITLE
#370 coverage cleanup and #365 Document coverage data generation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Description
+
+<!-- Update PR title to `Ticket : short description`>
+<!-- If no ticket exists for this issue yet, consider creating one -->
+
+**Reference ticket:** (HYRAX-xxx, #xxx)
+
+<!-- Description of task -->
+
+TODO
+
+## Tasks
+
+<!-- Ignore or delete any irrelevant items -->
+
+- [ ] Ticket exists and is linked in title
+- [ ] Tests added/updated
+- [ ] Dead code removed
+- [ ] No TODOs added

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+# Title
+
 ## Description
 
 <!-- Update PR title to `Ticket : short description`>

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,6 @@ jobs:
         - autoreconf --force --install --verbose
         - ./configure --disable-dependency-tracking --prefix=$prefix --enable-developer --enable-coverage
         - build-wrapper-linux-x86-64 --out-dir bw-output make -j$BUILD_PROCS
-        # - make check -j$BUILD_PROCS
         - build-wrapper-linux-x86-64 --out-dir bw-output make check -j$BUILD_PROCS
         # Force version 8.2 to work around an issue with the version bound to focal.
         # Using apt (the addons section at line 42) installs version 4.2 which has bugs
@@ -165,7 +164,6 @@ jobs:
         # into build-wrapper's compile_commands.json -- Sonar's C-family analyzer
         # can't attach coverage to files it doesn't know about, regardless of what
         # coverage.xml says. Does not fail the build; just logs the gap. jhrg 7/17/26
-        - python3 travis/check-coverage-compile-commands.py coverage.xml bw-output/compile_commands.json
         - sonar-scanner
         # The scanner waits for the quality gate because sonar.qualitygate.wait=true is set
         # in sonar-project.properties, so no extra badge/API polling is needed here.

--- a/README.coverage.md
+++ b/README.coverage.md
@@ -1,0 +1,99 @@
+# Test Coverage
+
+Test coverage can be computed by fist configuring and building the code for coverage.
+Once done, run both `make` and `make check`. The build process will produce a number of
+_.gcda and _.gcno files that contain the coverage information. Once that is done, use
+the `gcovr` too to get a summary of coverage and a set of HTML pages that contain statistics
+for each source file and a map of which lines are (or are not) covered by either the
+unit- or integration tests.
+
+> [!NOTE]
+> Make sure to not release code built for test coverage since _every_ method is instrumented
+> and thus runs more slowly.
+
+## Configuration and Build
+
+To configure a build for coverage analysis, use configure with the --enable-coverage option.
+
+```
+./configure --prefix=$prefix --enable-developer --enable-coverage
+```
+
+To build, run make and make check as normal. For example:
+
+```
+make -j20
+make -j20 check
+```
+
+The coverage data files are updated whenever a function is run, so if you run other programs
+using the library that are not part of the tests, that will alter the results, maybe
+resulting in code marked as 'covered' by a test when it was not.
+
+> [!TIP]
+> Once you have coverage data, re-run `configure` without `--enable-coverage` to get a better
+> performing library.
+
+## Getting the Coverage Report
+
+Use the gcovr tool to get coverage data in a usable form.
+
+### Settings for `gcovr`
+
+We have a small setting file for `gcovr`; see `gcovr.config` This excludes things that should
+not be counted. Some part of this file should be synchronized with the text in `sonar-project.properties`
+or the results show in teh SonarScan outout will be off.
+
+### Installing `gcovr`
+
+Install `gcovr` using homebrew, apt, pip, etc. However, be sure you are installing and
+using version 8.2 or greater of gcovr since since older versions have various issues.
+These include, not working with parallel test runs emitting broken data for SonarScan and
+generally under reporting coverage.
+
+> [!NOTE]
+> Note that Ubuntu Focal uses `gcovr` 4.x by default, and thus in Travis we force the 'scan'
+> step to use 8.2 using a `pip` install. Make sure to test the version of `gcovr` using
+> `gcovr --version`.
+
+### Running `gcovr`
+
+To collect coverage data, use:
+
+```
+gcovr --config gcovr.config
+```
+
+That will print out a bunch of text plus a nice summary of the coverage. The text is less than
+completely useful, but there are probably tools that use it.
+
+To get the summary stats and set of web pages that are easy to use but entail some clicking
+around:
+
+```
+gcovr --config gcovr.config --html-details coverage-html/coverage.html
+```
+
+Then open `coverage-html/coverage.html` as a file in your web browser.
+
+For sonarscan, we build the coverage data using:
+
+```
+gcovr --config gcovr.config --sonarqube coverage.xml
+```
+
+See [.tavis.yml](.travis.yml) in the `scan` block for code that collects coverage data
+for sonarscan. The data are uploaded to sonarscan using `sonar.coverageReportPaths=coverage.xml`
+in [sonar-project.properties](sonar-project.properties). I mention that here because it
+is hardly obvious from the Travis yaml just how the `coverage.xml` file gets uploaded to
+sonarscan.
+
+## Comparing results from different runs
+
+On the same OS and `gcovr` version, differences should only be from changes to the tests,
+the configuration or the `gcovr` version. However, `clang` (OSX) and `GNU gcc` (Linux) both
+handle some aspects of compilation differently, so the coverage counts will vary a bit.
+Also, SonarScan has its own notion of what is important and _combines_ the Line and Function
+counts into one number. While the Line and Function counts themselves are close between
+Sonar and Linux, the overall number will be lower than the Line count. Most people use
+the line count, making the most obvious number from Sonar somewhat misleading.

--- a/README.coverage.md
+++ b/README.coverage.md
@@ -1,9 +1,9 @@
 # Test Coverage
 
-Test coverage can be computed by fist configuring and building the code for coverage.
+Test coverage can be computed by first configuring and building the code for coverage.
 Once done, run both `make` and `make check`. The build process will produce a number of
-_.gcda and _.gcno files that contain the coverage information. Once that is done, use
-the `gcovr` too to get a summary of coverage and a set of HTML pages that contain statistics
+`*.gcda` and `*.gcno` files that contain the coverage information. Once that is done, use
+the `gcovr` tool to get a summary of coverage and a set of HTML pages that contain statistics
 for each source file and a map of which lines are (or are not) covered by either the
 unit- or integration tests.
 
@@ -15,13 +15,14 @@ unit- or integration tests.
 
 To configure a build for coverage analysis, use configure with the --enable-coverage option.
 
-```
+```bash
+export prefix=<the hyrax prefix dir>
 ./configure --prefix=$prefix --enable-developer --enable-coverage
 ```
 
 To build, run make and make check as normal. For example:
 
-```
+```bash
 make -j20
 make -j20 check
 ```
@@ -36,20 +37,20 @@ resulting in code marked as 'covered' by a test when it was not.
 
 ## Getting the Coverage Report
 
-Use the gcovr tool to get coverage data in a usable form.
+Use the `gcovr` tool to get coverage data in a usable form.
 
 ### Settings for `gcovr`
 
-We have a small setting file for `gcovr`; see `gcovr.config` This excludes things that should
+We have a small settings file for `gcovr`; see `gcovr.config` This excludes things that should
 not be counted. Some part of this file should be synchronized with the text in `sonar-project.properties`
-or the results show in teh SonarScan outout will be off.
+or the results show in the SonarScan output will be off.
 
 ### Installing `gcovr`
 
 Install `gcovr` using homebrew, apt, pip, etc. However, be sure you are installing and
-using version 8.2 or greater of gcovr since since older versions have various issues.
-These include, not working with parallel test runs emitting broken data for SonarScan and
-generally under reporting coverage.
+using version 8.2 or greater of gcovr since older versions have various issues.
+These include, not working with parallel test runs, emitting broken data for SonarScan, and
+under-reporting coverage.
 
 > [!NOTE]
 > Note that Ubuntu Focal uses `gcovr` 4.x by default, and thus in Travis we force the 'scan'
@@ -60,7 +61,7 @@ generally under reporting coverage.
 
 To collect coverage data, use:
 
-```
+```bash
 gcovr --config gcovr.config
 ```
 
@@ -70,7 +71,7 @@ completely useful, but there are probably tools that use it.
 To get the summary stats and set of web pages that are easy to use but entail some clicking
 around:
 
-```
+```bash
 gcovr --config gcovr.config --html-details coverage-html/coverage.html
 ```
 
@@ -78,11 +79,11 @@ Then open `coverage-html/coverage.html` as a file in your web browser.
 
 For sonarscan, we build the coverage data using:
 
-```
+```bash
 gcovr --config gcovr.config --sonarqube coverage.xml
 ```
 
-See [.tavis.yml](.travis.yml) in the `scan` block for code that collects coverage data
+See [.travis.yml](.travis.yml) in the `scan` block for code that collects coverage data
 for sonarscan. The data are uploaded to sonarscan using `sonar.coverageReportPaths=coverage.xml`
 in [sonar-project.properties](sonar-project.properties). I mention that here because it
 is hardly obvious from the Travis yaml just how the `coverage.xml` file gets uploaded to

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ From a release tarball:
 ./configure
 make
 make check
-make install
+make clean
+make dist
 ```
 
 From a git checkout:
@@ -39,6 +40,9 @@ autoreconf --force --install --verbose
 make
 make check
 ```
+
+Consider using `--prefix=$prefix --enable-developer` for any build where you will be
+working on the code.
 
 ## Requirements (summary)
 
@@ -57,6 +61,7 @@ For exact versions and platform notes, see [`INSTALL`](INSTALL).
 - [`NEWS`](NEWS): version-by-version release notes.
 - [`ChangeLog`](ChangeLog): detailed historical changes.
 - [`INSTALL`](INSTALL): build and install instructions.
+- [`README.coverage.md`](README.coverage.md): How to build coverage data.
 - [`README.dodsrc`](README.dodsrc): client `.dodsrc` behavior and options.
 - [`README.AIS`](README.AIS): historical AIS notes.
 - [`README.gh-pages.md`](README.gh-pages.md): publishing and maintenance notes for GitHub Pages docs.


### PR DESCRIPTION
# Document Coverage and Clean up

This PR adds a file documenting how to build the coverage data files (README.coverage.md) and removes a file leftover from debugging the differences in teh OSX, Linux and SonarScan coverage data.

See tickets #370 and #365.